### PR TITLE
feat: init flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,25 @@
+name: Nix
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  flake:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake outputs and run checks
+        run: nix flake check --print-build-logs
+
+      - name: Build package outputs
+        run: |
+          nix build .#plank --no-link --print-build-logs
+          nix build .#tree-sitter-plank --no-link --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 plank-tree-sitter/Cargo.lock
 *.vsix
 plank-doc/book/
+result

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ To install the compiler run:
 curl -L install.plankevm.org | bash && plankup
 ```
 
+Or, with Nix flakes enabled, run Plank directly from the flake:
+
+```bash
+nix run github:plankevm/plank-monorepo#plank -- --help
+```
+
+The Nix package includes the compiler, standard library, and local docs. The wrapped `plank` binary sets `PLANK_DIR` to the package output so `plank build` can find `stdlib/` and `plank doc` can find `share/doc/`.
+
 If you'd like to contribute please read the [Contributor Guidelines](./CONTRIBUTING.md).
 
 ## Contents

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,104 @@
+{
+  description = "Plank monorepo";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        rustPlatform = pkgs.rustPlatform;
+        plankDocs = pkgs.stdenvNoCC.mkDerivation {
+          pname = "plank-docs";
+          version = "0.1.0";
+          src = ./plank-doc;
+          nativeBuildInputs = [ pkgs.mdbook ];
+          buildPhase = ''
+            mdbook build
+          '';
+          installPhase = ''
+            mkdir -p $out/share/doc
+            cp -r book/. $out/share/doc/
+            cp -r src $out/share/doc/src
+          '';
+        };
+      in
+      {
+        packages.plank = rustPlatform.buildRustPackage {
+          pname = "plank";
+          version = "0.1.0";
+          src = ./plankc;
+          cargoLock = {
+            lockFile = ./plankc/Cargo.lock;
+          };
+          cargoBuildFlags = [ "-p" "plank" ];
+          postPatch = ''
+            cp -r ${./std} ../std
+          '';
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          postInstall = ''
+            mkdir -p $out/share/doc $out/stdlib
+            cp -r ${plankDocs}/share/doc/. $out/share/doc/
+            cp -r ${./std}/. $out/stdlib/
+            wrapProgram $out/bin/plank \
+              --set PLANK_DIR $out
+          '';
+          meta = with pkgs.lib; {
+            description = "Plank compiler CLI";
+            homepage = "https://github.com/plankevm/plank-monorepo";
+            license = licenses.mit;
+            mainProgram = "plank";
+          };
+        };
+
+        packages.tree-sitter-plank = pkgs.tree-sitter.buildGrammar {
+          language = "plank";
+          version = "0.1.0";
+          src = ./plank-tree-sitter;
+          meta = with pkgs.lib; {
+            description = "Plank grammar for tree-sitter";
+            homepage = "https://github.com/plankevm/plank-monorepo";
+            license = licenses.mit;
+          };
+        };
+        packages.default = self.packages.${system}.plank;
+
+        checks.examples-build = pkgs.runCommand "plank-examples-build" {
+          nativeBuildInputs = [ self.packages.${system}.plank ];
+        } ''
+          set -euo pipefail
+
+          plank build ${./plankc/examples/erc20_v1.plk}
+          plank build ${./plankc/plank-diff-tests/src/examples/erc20.plk}
+          plank build ${./plankc/plank-diff-tests/src/examples/merkle_airdrop.plk}
+          plank build ${./plankc/plank-diff-tests/src/examples/minimal_proxy.plk}
+          plank build ${./plankc/examples/multifile/main.plk} \
+            --module-name mymod \
+            --module-root ${./plankc/examples/multifile}
+          plank build ${./plankc/examples/multifile/main_glob.plk} \
+            --module-name mymod \
+            --module-root ${./plankc/examples/multifile}
+
+          touch $out
+        '';
+
+        checks.default = self.checks.${system}.examples-build;
+
+        apps.plank = {
+          type = "app";
+          program = "${self.packages.${system}.plank}/bin/plank";
+          meta = {
+            description = "Plank compiler CLI";
+          };
+        };
+
+        apps.default = self.apps.${system}.plank;
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ rustc cargo rustfmt clippy mdbook ];
+        };
+      });
+}

--- a/plank-doc/src/getting-started.md
+++ b/plank-doc/src/getting-started.md
@@ -16,6 +16,16 @@ To update Plank to the latest version, run:
 plankup
 ```
 
+### Nix
+
+If you use Nix with flakes enabled, you can run Plank directly from the flake:
+
+```bash
+nix run github:plankevm/plank-monorepo#plank -- --help
+```
+
+The Nix package includes the compiler, standard library, and local documentation. The `plank` binary is wrapped with `PLANK_DIR` pointing at the package output, so `plank build` automatically discovers `stdlib/` and `plank doc` opens the docs from `share/doc/`.
+
 ### Other Editors
 
 **Neovim**

--- a/plankc/examples/multifile/main.plk
+++ b/plankc/examples/multifile/main.plk
@@ -5,4 +5,5 @@ const local_val = MAGIC;
 
 init {
     let x = double(MAGIC);
+    @evm_stop();
 }

--- a/plankc/examples/multifile/main_glob.plk
+++ b/plankc/examples/multifile/main_glob.plk
@@ -4,4 +4,5 @@ const local_val = MAGIC;
 
 init {
     let x = double(MAGIC);
+    @evm_stop();
 }


### PR DESCRIPTION
## Changes

- Package the `plank` CLI with its stdlib and generated docs, wrapped with
  `PLANK_DIR` so `plank build` and `plank doc` work out of the box.
- Package the tree-sitter grammar as `tree-sitter-plank`.
- Add a flake check that compiles the example programs with the packaged CLI.
- Add a GitHub workflow to build the public Nix packages and run flake checks.

## Why?

It gives an alternate installation method which is not using a bash installation script with prebuilt binaries(which will probably not work on nix if it depends on dynamic linking now or in the future).

---

Not sure if you'd be interested in having this merged. It'd be nice to be able to `nix run github:plankevm/plank-monorepo`. If not I will create a separate repo for the plank flake and keep it out of tree. It gives an a