### PR TITLE
add sonatina backend

### DIFF
--- a/plankc/Cargo.lock
+++ b/plankc/Cargo.lock
@@ -596,6 +596,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,15 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +895,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.126.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006fe8776f6d81acb83571f52e7737a54c6dec1ba75e2b7b5a68af15451f88ee"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.126.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcca10e8c33eac67a45be4e09d236e274697831ca6bf4c4a927f7570eb8436a8"
+dependencies = [
+ "cranelift-bitset",
 ]
 
 [[package]]
@@ -908,6 +926,31 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -972,6 +1015,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "rayon",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,23 +1073,21 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.1.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.1.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
  "syn 2.0.117",
  "unicode-xid",
 ]
@@ -1062,6 +1118,11 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dot2"
+version = "1.0.0"
+source = "git+https://github.com/sanpii/dot2.rs.git#5c4ffa7182d3e6c14b91b94bb9efaad1e218022b"
 
 [[package]]
 name = "dyn-clone"
@@ -1331,6 +1392,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1469,6 +1536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1645,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1788,6 +1879,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1915,39 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -1898,6 +2045,7 @@ dependencies = [
  "plank-hir-eval",
  "plank-mir",
  "plank-mir-lower",
+ "plank-mir-lower-sona",
  "plank-session",
  "plank-source",
  "plank-test-utils",
@@ -1967,6 +2115,25 @@ dependencies = [
  "plank-values",
  "pretty_assertions",
  "sir-data",
+]
+
+[[package]]
+name = "plank-mir-lower-sona"
+version = "0.1.0"
+dependencies = [
+ "plank-core",
+ "plank-hir",
+ "plank-hir-eval",
+ "plank-mir",
+ "plank-session",
+ "plank-test-utils",
+ "plank-values",
+ "pretty_assertions",
+ "smallvec",
+ "sonatina-codegen",
+ "sonatina-ir",
+ "sonatina-triple",
+ "thiserror",
 ]
 
 [[package]]
@@ -2073,7 +2240,17 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
+dependencies = [
+ "fixed-hash",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2233,6 +2410,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2526,7 +2732,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.2",
@@ -2627,6 +2833,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -2889,6 +3101,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
+name = "sonatina-codegen"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "bit-set",
+ "cranelift-entity",
+ "dashmap",
+ "indexmap 2.13.0",
+ "rayon",
+ "rustc-hash",
+ "smallvec",
+ "sonatina-ir",
+ "sonatina-macros",
+ "sonatina-triple",
+ "sonatina-verifier",
+ "tracing",
+ "vec-collections",
+]
+
+[[package]]
+name = "sonatina-ir"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "cranelift-entity",
+ "dashmap",
+ "dot2",
+ "dyn-clone",
+ "indexmap 2.13.0",
+ "parking_lot",
+ "primitive-types 0.14.0",
+ "rayon",
+ "rustc-hash",
+ "smallvec",
+ "smol_str",
+ "sonatina-macros",
+ "sonatina-triple",
+ "vec-collections",
+]
+
+[[package]]
+name = "sonatina-macros"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sonatina-parser"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "annotate-snippets",
+ "bimap",
+ "cranelift-entity",
+ "derive_more",
+ "either",
+ "hex",
+ "pest",
+ "pest_derive",
+ "rustc-hash",
+ "smallvec",
+ "smol_str",
+ "sonatina-ir",
+ "sonatina-triple",
+ "tracing",
+]
+
+[[package]]
+name = "sonatina-triple"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "sonatina-verifier"
+version = "0.0.3-alpha"
+source = "git+https://github.com/fe-lang/sonatina?rev=5987a72#5987a721df740a30b65e2d66b63b3f4e3110babf"
+dependencies = [
+ "cranelift-entity",
+ "rayon",
+ "rustc-hash",
+ "smallvec",
+ "sonatina-ir",
+ "sonatina-macros",
+ "sonatina-parser",
+ "sonatina-triple",
+ "tracing",
+]
+
+[[package]]
+name = "sorted-iter"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bceb57dc07c92cdae60f5b27b3fa92ecaaa42fe36c55e22dbfb0b44893e0b1f7"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3452,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3504,20 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec-collections"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9965c8f2ffed1dbcd16cafe18a009642f540fa22661c6cfd6309ddb02e4982"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "lazy_static",
+ "num-traits",
+ "smallvec",
+ "sorted-iter",
+]
 
 [[package]]
 name = "version_check"

--- a/plankc/Cargo.toml
+++ b/plankc/Cargo.toml
@@ -25,6 +25,7 @@ plank-values = { path = "frontend/values" }
 plank-hir = { path = "frontend/hir" }
 plank-mir = { path = "frontend/mir" }
 plank-mir-lower = { path = "frontend/mir-lower" }
+plank-mir-lower-sona = { path = "frontend/mir-lower-sona" }
 plank-hir-eval = { path = "frontend/hir-eval" }
 plank-driver = { path = "frontend/driver" }
 

--- a/plankc/frontend/cli/src/main.rs
+++ b/plankc/frontend/cli/src/main.rs
@@ -3,15 +3,15 @@ use plank_test_utils as _;
 #[cfg(test)]
 use tempfile as _;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use owo_colors::OwoColorize;
-use plank_driver::Driver;
+use plank_driver::{BackendKind, Driver};
 use plank_hir::display::DisplayHir;
 use plank_mir::display::DisplayMir;
 use plank_parser::cst::display::DisplayCST;
 use plank_session::SourceId;
 use plank_source::source_fs::RealFs;
-use sir_passes::{OPTIMIZE_HELP, parse_optimizations_string};
+use sir_passes::OPTIMIZE_HELP;
 use std::{
     path::{Path, PathBuf},
     process,
@@ -60,15 +60,18 @@ struct BuildArgs {
 
     #[arg(
         long = "show-sir-first",
-        help = "show the SIR going into the middle end (directly after lowering from MIR)"
+        help = "show the selected backend IR before backend optimizations"
     )]
     show_sir_in: bool,
 
-    #[arg(long = "show-sir-final", help = "show the final SIR pre lowering to EVM assembly")]
+    #[arg(long = "show-sir-final", help = "show the selected backend IR before bytecode emission")]
     show_sir_last: bool,
 
-    #[arg(short = 'O', long = "optimize", help = OPTIMIZE_HELP, value_parser = parse_optimizations_string)]
+    #[arg(short = 'O', long = "optimize", help = optimize_help())]
     optimize: Option<String>,
+
+    #[arg(long = "backend", value_enum, default_value_t = BackendArg::Sir)]
+    backend: BackendArg,
 
     #[arg(long = "module-name")]
     module_name: Option<String>,
@@ -78,6 +81,29 @@ struct BuildArgs {
 
     #[arg(long = "dep", value_parser = parse_dep)]
     deps: Vec<(String, PathBuf)>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum BackendArg {
+    Sir,
+    Sona,
+}
+
+impl From<BackendArg> for BackendKind {
+    fn from(value: BackendArg) -> Self {
+        match value {
+            BackendArg::Sir => BackendKind::Sir,
+            BackendArg::Sona => BackendKind::Sona,
+        }
+    }
+}
+
+fn optimize_help() -> String {
+    format!(
+        "{OPTIMIZE_HELP}\n\n\
+        Sonatina backend optimization levels: O0, O1, Os, O2. Default is O0.\n\
+        Examples: --backend sona -O1, --backend sona -O2"
+    )
 }
 
 fn parse_dep(s: &str) -> Result<(String, PathBuf), String> {
@@ -226,13 +252,16 @@ fn build(plank_dir: Option<PathBuf>, args: BuildArgs) {
         driver.render_diagnostics_and_exit();
     }
 
-    let bytecode = driver.emit_bytecode(
-        &mir,
-        args.optimize.as_deref(),
-        needs_separators,
-        args.show_sir_in,
-        args.show_sir_last,
-    );
+    let bytecode = driver
+        .emit_bytecode_with_backend(
+            &mir,
+            args.optimize.as_deref(),
+            needs_separators,
+            args.show_sir_in,
+            args.show_sir_last,
+            args.backend.into(),
+        )
+        .unwrap_or_else(|err| cli_error_and_exit(err));
 
     print!("0x");
     for byte in bytecode {

--- a/plankc/frontend/driver/Cargo.toml
+++ b/plankc/frontend/driver/Cargo.toml
@@ -14,6 +14,7 @@ plank-hir.workspace = true
 plank-hir-eval.workspace = true
 plank-mir.workspace = true
 plank-mir-lower.workspace = true
+plank-mir-lower-sona.workspace = true
 plank-values.workspace = true
 sir-debug-backend.workspace = true
 sir-passes.workspace = true

--- a/plankc/frontend/driver/src/lib.rs
+++ b/plankc/frontend/driver/src/lib.rs
@@ -4,8 +4,18 @@ use plank_source::{
     ModuleResolver, ParsedProject, diagnostics, parse_project, source_fs::SourceFs,
 };
 use plank_values::ValueInterner;
-use sir_passes::PassManager;
-use std::path::{Path, PathBuf};
+use sir_passes::{PassManager, parse_optimizations_string};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BackendKind {
+    #[default]
+    Sir,
+    Sona,
+}
 
 pub struct Driver<'a, F: SourceFs> {
     pub session: Session,
@@ -79,34 +89,130 @@ impl<'a, F: SourceFs> Driver<'a, F> {
         show_sir_in: bool,
         show_sir_last: bool,
     ) -> Vec<u8> {
+        self.emit_bytecode_with_backend(
+            mir,
+            optimizations,
+            disp_needs_separators,
+            show_sir_in,
+            show_sir_last,
+            BackendKind::Sir,
+        )
+        .expect("SIR bytecode emission should not fail")
+    }
+
+    pub fn emit_bytecode_with_backend(
+        &self,
+        mir: &plank_mir::Mir,
+        optimizations: Option<&str>,
+        disp_needs_separators: bool,
+        show_sir_in: bool,
+        show_sir_last: bool,
+        backend: BackendKind,
+    ) -> Result<Vec<u8>, String> {
+        match backend {
+            BackendKind::Sir => self.emit_sir_bytecode(
+                mir,
+                optimizations,
+                disp_needs_separators,
+                show_sir_in,
+                show_sir_last,
+            ),
+            BackendKind::Sona => self.emit_sona_bytecode(
+                mir,
+                optimizations,
+                disp_needs_separators,
+                show_sir_in,
+                show_sir_last,
+            ),
+        }
+    }
+
+    fn emit_sir_bytecode(
+        &self,
+        mir: &plank_mir::Mir,
+        optimizations: Option<&str>,
+        disp_needs_separators: bool,
+        show_sir_in: bool,
+        show_sir_last: bool,
+    ) -> Result<Vec<u8>, String> {
         let mut program = plank_mir_lower::lower(mir, &self.values);
         if show_sir_in {
-            if disp_needs_separators {
-                eprintln!("\n");
-                eprintln!("////////////////////////////////////////////////////////////////");
-                eprintln!("//                           SIR IN                           //");
-                eprintln!("////////////////////////////////////////////////////////////////");
-            }
-            eprintln!("{}", program);
+            print_backend_ir("SIR IN", disp_needs_separators, &program);
         }
         let mut pass_manager = PassManager::new(&mut program);
         pass_manager.run_ssa_transform();
         if let Some(passes) = optimizations {
+            parse_optimizations_string(passes)?;
             pass_manager.run_optimizations(passes);
         }
         if show_sir_last {
-            if disp_needs_separators {
-                eprintln!("\n");
-                eprintln!("////////////////////////////////////////////////////////////////");
-                eprintln!("//                          SIR LAST                          //");
-                eprintln!("////////////////////////////////////////////////////////////////");
-            }
-            eprintln!("{}", program);
+            print_backend_ir("SIR LAST", disp_needs_separators, &program);
         }
         let mut bytecode = Vec::with_capacity(0x6000);
         sir_debug_backend::ir_to_bytecode(&program, &mut bytecode);
-        bytecode
+        Ok(bytecode)
     }
+
+    fn emit_sona_bytecode(
+        &self,
+        mir: &plank_mir::Mir,
+        optimizations: Option<&str>,
+        disp_needs_separators: bool,
+        show_sir_in: bool,
+        show_sir_last: bool,
+    ) -> Result<Vec<u8>, String> {
+        let opt_level = parse_sona_opt_level(optimizations)?;
+        if show_sir_in {
+            print_backend_ir(
+                "SONA IR",
+                disp_needs_separators,
+                plank_mir_lower_sona::emit_ir(
+                    mir,
+                    &self.values,
+                    plank_mir_lower_sona::OptLevel::O0,
+                )
+                .map_err(|err| err.to_string())?,
+            );
+        }
+        if show_sir_last {
+            print_backend_ir(
+                "SONA IR OPT",
+                disp_needs_separators,
+                plank_mir_lower_sona::emit_ir(mir, &self.values, opt_level)
+                    .map_err(|err| err.to_string())?,
+            );
+        }
+        plank_mir_lower_sona::emit_bytecode(mir, &self.values, opt_level)
+            .map_err(|err| err.to_string())
+    }
+}
+
+fn parse_sona_opt_level(
+    optimizations: Option<&str>,
+) -> Result<plank_mir_lower_sona::OptLevel, String> {
+    let Some(optimizations) = optimizations else {
+        return Ok(plank_mir_lower_sona::OptLevel::O0);
+    };
+
+    match optimizations.to_ascii_lowercase().as_str() {
+        "0" | "o0" => Ok(plank_mir_lower_sona::OptLevel::O0),
+        "1" | "o1" => Ok(plank_mir_lower_sona::OptLevel::O1),
+        "s" | "os" => Ok(plank_mir_lower_sona::OptLevel::Os),
+        "2" | "o2" => Ok(plank_mir_lower_sona::OptLevel::O2),
+        _ => Err(format!(
+            "invalid Sona optimization level '{optimizations}', valid levels: O0, O1, Os, O2"
+        )),
+    }
+}
+
+fn print_backend_ir(title: &str, disp_needs_separators: bool, ir: impl Display) {
+    if disp_needs_separators {
+        eprintln!("\n");
+        eprintln!("////////////////////////////////////////////////////////////////");
+        eprintln!("//{title:^60}//");
+        eprintln!("////////////////////////////////////////////////////////////////");
+    }
+    eprintln!("{ir}");
 }
 
 #[cfg(test)]
@@ -114,6 +220,24 @@ mod tests {
     use super::*;
     use plank_source::source_fs::InMemoryFs;
     use plank_test_utils::{assert_diagnostics, dedent_preserve_indent};
+
+    #[test]
+    fn parse_sona_opt_level_accepts_explicit_levels() {
+        assert_eq!(parse_sona_opt_level(None).unwrap(), plank_mir_lower_sona::OptLevel::O0);
+        assert_eq!(parse_sona_opt_level(Some("0")).unwrap(), plank_mir_lower_sona::OptLevel::O0);
+        assert_eq!(parse_sona_opt_level(Some("O0")).unwrap(), plank_mir_lower_sona::OptLevel::O0);
+        assert_eq!(parse_sona_opt_level(Some("O1")).unwrap(), plank_mir_lower_sona::OptLevel::O1);
+        assert_eq!(parse_sona_opt_level(Some("Os")).unwrap(), plank_mir_lower_sona::OptLevel::Os);
+        assert_eq!(parse_sona_opt_level(Some("O2")).unwrap(), plank_mir_lower_sona::OptLevel::O2);
+    }
+
+    #[test]
+    fn parse_sona_opt_level_rejects_sir_passes() {
+        assert_eq!(
+            parse_sona_opt_level(Some("csud")).unwrap_err(),
+            "invalid Sona optimization level 'csud', valid levels: O0, O1, Os, O2"
+        );
+    }
 
     #[test]
     fn duplicate_dep_emits_diagnostic() {

--- a/plankc/frontend/mir-lower-sona/Cargo.toml
+++ b/plankc/frontend/mir-lower-sona/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "plank-mir-lower-sona"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+plank-core.workspace = true
+plank-mir.workspace = true
+plank-session.workspace = true
+plank-values.workspace = true
+smallvec.workspace = true
+sonatina-codegen = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+sonatina-ir = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+sonatina-triple = { git = "https://github.com/fe-lang/sonatina", rev = "5987a72" }
+thiserror.workspace = true
+
+[dev-dependencies]
+plank-hir.workspace = true
+plank-hir-eval.workspace = true
+plank-test-utils.workspace = true
+pretty_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/plankc/frontend/mir-lower-sona/src/function.rs
+++ b/plankc/frontend/mir-lower-sona/src/function.rs
@@ -1,0 +1,637 @@
+use crate::module::{RuntimeShapes, runtime_shape};
+use plank_core::{DenseIndexMap, Idx};
+use plank_mir::{self as mir, Expr, Instruction, Mir};
+use plank_session::RuntimeBuiltin;
+use plank_values::{Type as PlankType, TypeId, Value, ValueId, ValueInterner};
+use smallvec::SmallVec;
+use sonatina_ir::{
+    BlockId, HasInst, I256, Immediate, Inst, Type as SonaType, ValueId as SonaValueId,
+    builder::{FunctionBuilder, ModuleBuilder, Variable},
+    func_cursor::InstInserter,
+    inst::{
+        arith::{Add, Mul, Sar, Shl, Shr, Sub},
+        cast::PtrToInt,
+        cmp::{Eq, Gt, IsZero, Lt, Ne, Sgt, Slt},
+        control_flow::{Br, Jump},
+        data::{ExtractValue, InsertValue, Mload, Mstore, SymAddr, SymSize, SymbolRef},
+        evm::{inst_set::EvmInstSet, *},
+        logic::{And, Not, Or, Xor},
+    },
+    module::FuncRef,
+    object::EmbedSymbol,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BlockExit {
+    Loose,
+    Terminated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltinOutput {
+    Value(SonaValueId),
+    NoValue,
+    Terminator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputKind {
+    Value,
+    NoValue,
+    Terminator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemoryOp {
+    Load(u16),
+    Store(u16),
+}
+
+fn memory_op(b: RuntimeBuiltin) -> Option<MemoryOp> {
+    use RuntimeBuiltin as B;
+    macro_rules! m {
+        ($(($l:ident, $s:ident, $n:literal)),* $(,)?) => {
+            match b {
+                $(B::$l => Some(MemoryOp::Load($n)),)*
+                $(B::$s => Some(MemoryOp::Store($n)),)*
+                _ => None,
+            }
+        };
+    }
+    m! {
+        (MLoad1, MStore1, 1),    (MLoad2, MStore2, 2),    (MLoad3, MStore3, 3),
+        (MLoad4, MStore4, 4),    (MLoad5, MStore5, 5),    (MLoad6, MStore6, 6),
+        (MLoad7, MStore7, 7),    (MLoad8, MStore8, 8),    (MLoad9, MStore9, 9),
+        (MLoad10, MStore10, 10), (MLoad11, MStore11, 11), (MLoad12, MStore12, 12),
+        (MLoad13, MStore13, 13), (MLoad14, MStore14, 14), (MLoad15, MStore15, 15),
+        (MLoad16, MStore16, 16), (MLoad17, MStore17, 17), (MLoad18, MStore18, 18),
+        (MLoad19, MStore19, 19), (MLoad20, MStore20, 20), (MLoad21, MStore21, 21),
+        (MLoad22, MStore22, 22), (MLoad23, MStore23, 23), (MLoad24, MStore24, 24),
+        (MLoad25, MStore25, 25), (MLoad26, MStore26, 26), (MLoad27, MStore27, 27),
+        (MLoad28, MStore28, 28), (MLoad29, MStore29, 29), (MLoad30, MStore30, 30),
+        (MLoad31, MStore31, 31), (MLoad32, MStore32, 32),
+    }
+}
+
+pub(crate) struct FunctionLowerer<'a> {
+    mir: &'a Mir,
+    values: &'a ValueInterner,
+    fn_id: mir::FnId,
+    fb: FunctionBuilder<InstInserter>,
+    is: &'static EvmInstSet,
+    funcs: &'a DenseIndexMap<mir::FnId, FuncRef>,
+    local_vars: DenseIndexMap<mir::LocalId, Option<(Variable, SonaType)>>,
+    runtime_shapes: &'a RuntimeShapes,
+}
+
+impl<'a> FunctionLowerer<'a> {
+    pub(crate) fn new(
+        builder: &ModuleBuilder,
+        is: &'static EvmInstSet,
+        mir: &'a Mir,
+        values: &'a ValueInterner,
+        funcs: &'a DenseIndexMap<mir::FnId, FuncRef>,
+        runtime_shapes: &'a RuntimeShapes,
+        fn_id: mir::FnId,
+    ) -> Self {
+        let mut fb = builder.func_builder::<InstInserter>(funcs[fn_id]);
+        let entry = fb.append_block();
+        fb.switch_to_block(entry);
+        Self {
+            mir,
+            values,
+            fn_id,
+            fb,
+            is,
+            funcs,
+            local_vars: DenseIndexMap::with_capacity(mir.fn_locals[fn_id].len()),
+            runtime_shapes,
+        }
+    }
+
+    pub(crate) fn lower(mut self) {
+        for (idx, &ty) in self.mir.fn_locals[self.fn_id].iter().enumerate() {
+            let local = mir::LocalId::new(idx as u32);
+            let slot = self.shape(ty).map(|ty| (self.fb.declare_var(ty), ty));
+            self.local_vars.insert_no_prev(local, slot);
+        }
+
+        let mut arg_idx = 0;
+        for param in self.mir.fns[self.fn_id].iter_params() {
+            if let Some((var, _)) = self.local_slot(param) {
+                let arg = self.fb.args()[arg_idx];
+                self.fb.def_var(var, arg);
+                arg_idx += 1;
+            }
+        }
+        assert_eq!(arg_idx, self.fb.args().len());
+
+        if self.lower_block(self.mir.fns[self.fn_id].body) == BlockExit::Loose {
+            self.fb.insert_inst_no_result(EvmInvalid::new(self.is));
+        }
+        self.fb.seal_all();
+        self.fb.finish();
+    }
+
+    fn lower_block(&mut self, block: mir::BlockId) -> BlockExit {
+        for &instr in &self.mir.blocks[block] {
+            let exit = match instr {
+                Instruction::Set { target, expr } => self.lower_set(target, expr),
+                Instruction::Return(local) => {
+                    let value = self.read_local(local);
+                    self.fb.insert_return_values(value.as_slice());
+                    return BlockExit::Terminated;
+                }
+                Instruction::If { condition, then_block, else_block } => {
+                    self.lower_if(condition, then_block, else_block)
+                }
+                Instruction::While { condition_block, condition, body } => {
+                    self.lower_while(condition_block, condition, body)
+                }
+            };
+            if exit == BlockExit::Terminated {
+                return BlockExit::Terminated;
+            }
+        }
+        BlockExit::Loose
+    }
+
+    fn lower_set(&mut self, target: mir::LocalId, expr: Expr) -> BlockExit {
+        match expr {
+            Expr::Const(value) => {
+                let value = self.materialize_constant(value);
+                self.write_local(target, value);
+            }
+            Expr::LocalRef(src) => {
+                let value = self.read_local(src);
+                self.write_local(target, value);
+            }
+            Expr::RuntimeBuiltinCall { builtin, args } => {
+                let result_ty = self.shape(self.mir.fn_locals[self.fn_id][target.idx()]);
+                assert!(
+                    !result_ty.is_some_and(SonaType::is_compound),
+                    "{builtin} cannot return an aggregate value"
+                );
+                match self.lower_builtin(builtin, args, result_ty) {
+                    BuiltinOutput::Value(value) => self.write_local(target, Some(value)),
+                    BuiltinOutput::NoValue => self.write_local(target, None),
+                    BuiltinOutput::Terminator => return BlockExit::Terminated,
+                }
+            }
+            Expr::Call { callee, args } => {
+                let call_args = self.mir.args[args]
+                    .iter()
+                    .filter_map(|&arg| self.read_local(arg))
+                    .collect::<SmallVec<[SonaValueId; 8]>>();
+                let results = self.fb.insert_call_results(self.funcs[callee], call_args);
+                let value = match self.local_slot(target) {
+                    None => {
+                        assert!(results.is_empty());
+                        None
+                    }
+                    Some(_) => {
+                        assert_eq!(results.len(), 1);
+                        Some(results[0])
+                    }
+                };
+                self.write_local(target, value);
+                if self.mir.fns[callee].return_type == TypeId::NEVER {
+                    self.fb.insert_inst_no_result(EvmInvalid::new(self.is));
+                    return BlockExit::Terminated;
+                }
+            }
+            Expr::StructLit { ty, fields } => {
+                let value = self.build_aggregate(ty, self.mir.args[fields].len(), |this, i| {
+                    this.read_local(this.mir.args[fields][i])
+                });
+                self.write_local(target, value);
+            }
+            Expr::FieldAccess { object, field_index } => {
+                let value = self.read_field(object, field_index);
+                self.write_local(target, value);
+            }
+        }
+        BlockExit::Loose
+    }
+
+    fn lower_if(
+        &mut self,
+        condition: mir::LocalId,
+        then_block: mir::BlockId,
+        else_block: mir::BlockId,
+    ) -> BlockExit {
+        let else_ = self.fb.append_block();
+        let then_ = self.fb.append_block();
+        let condition = self.read_condition(condition);
+        self.br(condition, then_, else_);
+
+        self.fb.switch_to_block(then_);
+        let then_exit = self.lower_block(then_block);
+        let then_end = (then_exit == BlockExit::Loose)
+            .then(|| self.fb.current_block().expect("loose then-branch must have a current block"));
+
+        self.fb.switch_to_block(else_);
+        let else_exit = self.lower_block(else_block);
+        let else_end = (else_exit == BlockExit::Loose)
+            .then(|| self.fb.current_block().expect("loose else-branch must have a current block"));
+
+        if then_end.is_none() && else_end.is_none() {
+            return BlockExit::Terminated;
+        }
+
+        let merge = self.fb.append_block();
+        if let Some(then_end) = then_end {
+            self.fb.switch_to_block(then_end);
+            self.jump(merge);
+        }
+        if let Some(else_end) = else_end {
+            self.fb.switch_to_block(else_end);
+            self.jump(merge);
+        }
+
+        self.fb.switch_to_block(merge);
+        BlockExit::Loose
+    }
+
+    fn lower_while(
+        &mut self,
+        condition_block: mir::BlockId,
+        condition: mir::LocalId,
+        body: mir::BlockId,
+    ) -> BlockExit {
+        let condition_sona = self.fb.append_block();
+        self.jump(condition_sona);
+
+        self.fb.switch_to_block(condition_sona);
+        if self.lower_block(condition_block) == BlockExit::Terminated {
+            return BlockExit::Terminated;
+        }
+
+        let body_sona = self.fb.append_block();
+        let continue_sona = self.fb.append_block();
+        let condition = self.read_condition(condition);
+        self.br(condition, body_sona, continue_sona);
+
+        self.fb.switch_to_block(body_sona);
+        if self.lower_block(body) == BlockExit::Loose {
+            self.jump(condition_sona);
+        }
+
+        self.fb.switch_to_block(continue_sona);
+        BlockExit::Loose
+    }
+
+    fn local_slot(&self, local: mir::LocalId) -> Option<(Variable, SonaType)> {
+        self.local_vars[local]
+    }
+
+    fn read_local(&mut self, local: mir::LocalId) -> Option<SonaValueId> {
+        self.local_slot(local).map(|(var, _)| self.fb.use_var(var))
+    }
+
+    fn read_value(&mut self, local: mir::LocalId) -> SonaValueId {
+        self.read_local(local).expect("local has no runtime value")
+    }
+
+    fn write_local(&mut self, local: mir::LocalId, value: Option<SonaValueId>) {
+        match (self.local_slot(local), value) {
+            (None, None) => {}
+            (Some((var, _)), Some(value)) => self.fb.def_var(var, value),
+            (None, Some(_)) => panic!("zero-sized local {local:?} got a value"),
+            (Some(_), None) => panic!("valued local {local:?} got no value"),
+        }
+    }
+
+    fn shape(&self, ty: TypeId) -> Option<SonaType> {
+        runtime_shape(self.runtime_shapes, ty)
+    }
+
+    fn read_condition(&mut self, local: mir::LocalId) -> SonaValueId {
+        let condition = self.read_value(local);
+        let condition_ty = self.fb.type_of(condition);
+        if condition_ty == SonaType::I1 {
+            condition
+        } else {
+            let zero = self.fb.make_imm_value(Immediate::from_i256(I256::from(0), condition_ty));
+            self.fb.insert_inst(Ne::new(self.is, condition, zero), SonaType::I1)
+        }
+    }
+
+    fn build_aggregate(
+        &mut self,
+        ty: TypeId,
+        field_count: usize,
+        mut get_field: impl FnMut(&mut Self, usize) -> Option<SonaValueId>,
+    ) -> Option<SonaValueId> {
+        let PlankType::Struct(struct_) = self.mir.types.lookup(ty) else {
+            panic!("struct aggregate on non-struct");
+        };
+        assert_eq!(struct_.fields.len(), field_count);
+        let struct_ty = self.shape(ty)?;
+        let mut aggregate = self.fb.make_undef_value(struct_ty);
+        for i in 0..field_count {
+            if let Some(field_value) = get_field(self, i) {
+                let i = u32::try_from(i).expect("struct field index must fit in u32");
+                let idx = self.imm_256(i);
+                aggregate = self.fb.insert_inst(
+                    InsertValue::new_unchecked(self.is, aggregate, idx, field_value),
+                    struct_ty,
+                );
+            }
+        }
+        Some(aggregate)
+    }
+
+    fn read_field(&mut self, object: mir::LocalId, field_index: u32) -> Option<SonaValueId> {
+        let object_type = self.mir.fn_locals[self.fn_id][object.idx()];
+        let PlankType::Struct(struct_) = self.mir.types.lookup(object_type) else {
+            panic!("field access on non-struct");
+        };
+        let field_ty = self.shape(struct_.fields[field_index as usize].ty)?;
+        let object_value = self.read_value(object);
+        let idx = self.imm_256(field_index);
+        Some(self.fb.insert_inst(ExtractValue::new_unchecked(self.is, object_value, idx), field_ty))
+    }
+
+    fn materialize_constant(&mut self, value: ValueId) -> Option<SonaValueId> {
+        match self.values.lookup(value) {
+            Value::Void => None,
+            Value::Bool(value) => Some(self.fb.make_imm_value(Immediate::I1(value))),
+            Value::BigNum(value) => {
+                let bytes = value.to_be_bytes::<32>();
+                let value = sonatina_ir::U256::from_big_endian(&bytes);
+                Some(
+                    self.fb.make_imm_value(Immediate::from_i256(I256::from(value), SonaType::I256)),
+                )
+            }
+            Value::StructVal { ty, fields } => self
+                .build_aggregate(ty, fields.len(), |this, i| this.materialize_constant(fields[i])),
+            Value::Type(_) | Value::Closure { .. } => panic!("comptime-only value in MIR"),
+        }
+    }
+
+    fn imm_256(&mut self, n: u32) -> SonaValueId {
+        self.fb.make_imm_value(Immediate::from_i256(I256::from(n), SonaType::I256))
+    }
+
+    fn jump(&mut self, target: BlockId) {
+        self.fb.insert_inst_no_result(Jump::new(self.is, target));
+    }
+
+    fn br(&mut self, cond: SonaValueId, then: BlockId, else_: BlockId) {
+        self.fb.insert_inst_no_result(Br::new(self.is, cond, then, else_));
+    }
+
+    fn lower_builtin(
+        &mut self,
+        op: RuntimeBuiltin,
+        args: mir::ArgsId,
+        rty: Option<SonaType>,
+    ) -> BuiltinOutput {
+        use OutputKind::*;
+        use RuntimeBuiltin as B;
+
+        macro_rules! emit {
+            ($make:path, [$($a:ident),* $(,)?], $kind:expr) => {
+                self.emit(op, args, rty, $kind, |is, [$($a),*]| $make(is, $($a),*))
+            };
+        }
+        match op {
+            B::Add => emit!(Add::new, [a, b], Value),
+            B::Mul => emit!(Mul::new, [a, b], Value),
+            B::Sub => emit!(Sub::new, [a, b], Value),
+            B::Div => emit!(EvmUdiv::new, [a, b], Value),
+            B::SDiv => emit!(EvmSdiv::new, [a, b], Value),
+            B::Mod => emit!(EvmUmod::new, [a, b], Value),
+            B::SMod => emit!(EvmSmod::new, [a, b], Value),
+            B::AddMod => emit!(EvmAddMod::new, [a, b, c], Value),
+            B::MulMod => emit!(EvmMulMod::new, [a, b, c], Value),
+            B::Exp => emit!(EvmExp::new, [a, b], Value),
+            B::SignExtend => emit!(EvmSignExtend::new, [a, b], Value),
+
+            B::Lt => emit!(Lt::new, [a, b], Value),
+            B::Gt => emit!(Gt::new, [a, b], Value),
+            B::SLt => emit!(Slt::new, [a, b], Value),
+            B::SGt => emit!(Sgt::new, [a, b], Value),
+            B::Eq => emit!(Eq::new, [a, b], Value),
+            B::IsZero => emit!(IsZero::new, [a], Value),
+            B::And => emit!(And::new, [a, b], Value),
+            B::Or => emit!(Or::new, [a, b], Value),
+            B::Xor => emit!(Xor::new, [a, b], Value),
+            B::Not => emit!(Not::new, [a], Value),
+            B::Byte => emit!(EvmByte::new, [a, b], Value),
+            B::Shl => emit!(Shl::new, [a, b], Value),
+            B::Shr => emit!(Shr::new, [a, b], Value),
+            B::Sar => emit!(Sar::new, [a, b], Value),
+
+            B::Keccak256 => emit!(EvmKeccak256::new, [a, b], Value),
+            B::Address => emit!(EvmAddress::new, [], Value),
+            B::Balance => emit!(EvmBalance::new, [a], Value),
+            B::Origin => emit!(EvmOrigin::new, [], Value),
+            B::Caller => emit!(EvmCaller::new, [], Value),
+            B::CallValue => emit!(EvmCallValue::new, [], Value),
+            B::CallDataLoad => emit!(EvmCalldataLoad::new, [a], Value),
+            B::CallDataSize => emit!(EvmCalldataSize::new, [], Value),
+            B::CallDataCopy => emit!(EvmCalldataCopy::new, [a, b, c], NoValue),
+            B::CodeSize => emit!(EvmCodeSize::new, [], Value),
+            B::CodeCopy => emit!(EvmCodeCopy::new, [a, b, c], NoValue),
+            B::GasPrice => emit!(EvmGasPrice::new, [], Value),
+            B::ExtCodeSize => emit!(EvmExtCodeSize::new, [a], Value),
+            B::ExtCodeCopy => emit!(EvmExtCodeCopy::new, [a, b, c, d], NoValue),
+            B::ReturnDataSize => emit!(EvmReturnDataSize::new, [], Value),
+            B::ReturnDataCopy => emit!(EvmReturnDataCopy::new, [a, b, c], NoValue),
+            B::ExtCodeHash => emit!(EvmExtCodeHash::new, [a], Value),
+            B::Gas => emit!(EvmGas::new, [], Value),
+
+            B::BlockHash => emit!(EvmBlockHash::new, [a], Value),
+            B::Coinbase => emit!(EvmCoinBase::new, [], Value),
+            B::Timestamp => emit!(EvmTimestamp::new, [], Value),
+            B::Number => emit!(EvmNumber::new, [], Value),
+            B::Difficulty => emit!(EvmPrevRandao::new, [], Value),
+            B::GasLimit => emit!(EvmGasLimit::new, [], Value),
+            B::ChainId => emit!(EvmChainId::new, [], Value),
+            B::SelfBalance => emit!(EvmSelfBalance::new, [], Value),
+            B::BaseFee => emit!(EvmBaseFee::new, [], Value),
+            B::BlobHash => emit!(EvmBlobHash::new, [a], Value),
+            B::BlobBaseFee => emit!(EvmBlobBaseFee::new, [], Value),
+
+            B::SLoad => emit!(EvmSload::new, [a], Value),
+            B::SStore => emit!(EvmSstore::new, [a, b], NoValue),
+            B::TLoad => emit!(EvmTload::new, [a], Value),
+            B::TStore => emit!(EvmTstore::new, [a, b], NoValue),
+
+            B::Log0 => emit!(EvmLog0::new, [a, b], NoValue),
+            B::Log1 => emit!(EvmLog1::new, [a, b, c], NoValue),
+            B::Log2 => emit!(EvmLog2::new, [a, b, c, d], NoValue),
+            B::Log3 => emit!(EvmLog3::new, [a, b, c, d, e], NoValue),
+            B::Log4 => emit!(EvmLog4::new, [a, b, c, d, e, f], NoValue),
+
+            B::Create => emit!(EvmCreate::new, [a, b, c], Value),
+            B::Create2 => emit!(EvmCreate2::new, [a, b, c, d], Value),
+            B::Call => emit!(EvmCall::new, [a, b, c, d, e, f, g], Value),
+            B::CallCode => emit!(EvmCallCode::new, [a, b, c, d, e, f, g], Value),
+            B::DelegateCall => emit!(EvmDelegateCall::new, [a, b, c, d, e, f], Value),
+            B::StaticCall => emit!(EvmStaticCall::new, [a, b, c, d, e, f], Value),
+            B::Return => emit!(EvmReturn::new, [a, b], Terminator),
+            B::Stop => emit!(EvmStop::new, [], Terminator),
+            B::Revert => emit!(EvmRevert::new, [a, b], Terminator),
+            B::Invalid => emit!(EvmInvalid::new, [], Terminator),
+            B::SelfDestruct => emit!(EvmSelfDestruct::new, [a], Terminator),
+
+            B::DynamicAllocZeroed => self.alloc(op, args, rty, true),
+            B::DynamicAllocAnyBytes => self.alloc(op, args, rty, false),
+            B::MemoryCopy => emit!(EvmMcopy::new, [a, b, c], NoValue),
+
+            B::RuntimeStartOffset => {
+                let result_ty = rty.expect("builtin should produce a value");
+                let result = if self.mir.run.is_some() {
+                    let symbol = SymbolRef::Embed(EmbedSymbol::from(crate::RUNTIME_SECTION));
+                    self.fb.insert_inst(SymAddr::new(self.is, symbol), result_ty)
+                } else {
+                    self.fb.insert_inst(SymSize::new(self.is, SymbolRef::CurrentSection), result_ty)
+                };
+                BuiltinOutput::Value(result)
+            }
+            B::InitEndOffset => {
+                let result_ty = rty.expect("builtin should produce a value");
+                BuiltinOutput::Value(
+                    self.fb
+                        .insert_inst(SymSize::new(self.is, SymbolRef::CurrentSection), result_ty),
+                )
+            }
+            B::RuntimeLength => {
+                let result_ty = rty.expect("builtin should produce a value");
+                let result = if self.mir.run.is_some() {
+                    let symbol = SymbolRef::Embed(EmbedSymbol::from(crate::RUNTIME_SECTION));
+                    self.fb.insert_inst(SymSize::new(self.is, symbol), result_ty)
+                } else {
+                    self.imm_256(0)
+                };
+                BuiltinOutput::Value(result)
+            }
+
+            builtin => match memory_op(builtin) {
+                Some(MemoryOp::Load(bytes)) => {
+                    let [addr] = self.arg_values(builtin, args);
+                    let word = self.i256_inst(Mload::new(self.is, addr, SonaType::I256));
+                    if bytes == 32 {
+                        return BuiltinOutput::Value(word);
+                    }
+                    let bits = self.imm_256(256 - bytes as u32 * 8);
+                    let shifted = self.i256_inst(Shr::new(self.is, bits, word));
+                    BuiltinOutput::Value(shifted)
+                }
+                Some(MemoryOp::Store(bytes)) => {
+                    let [addr, value] = self.arg_values(builtin, args);
+                    if bytes == 32 {
+                        self.fb.insert_inst_no_result(Mstore::new(
+                            self.is,
+                            addr,
+                            value,
+                            SonaType::I256,
+                        ));
+                        return BuiltinOutput::NoValue;
+                    }
+                    if bytes == 1 {
+                        self.fb.insert_inst_no_result(EvmMstore8::new(self.is, addr, value));
+                        return BuiltinOutput::NoValue;
+                    }
+
+                    let bits = bytes as u32 * 8;
+                    let tail_bits = self.imm_256(256 - bits);
+                    let bits = self.imm_256(bits);
+
+                    let tail = self.i256_inst(Mload::new(self.is, addr, SonaType::I256));
+                    let tail = self.i256_inst(Shl::new(self.is, bits, tail));
+                    let tail = self.i256_inst(Shr::new(self.is, bits, tail));
+                    let value = self.i256_inst(Shl::new(self.is, tail_bits, value));
+                    let updated = self.i256_inst(Or::new(self.is, tail, value));
+                    self.fb.insert_inst_no_result(Mstore::new(
+                        self.is,
+                        addr,
+                        updated,
+                        SonaType::I256,
+                    ));
+                    BuiltinOutput::NoValue
+                }
+                None => panic!("unsupported RuntimeBuiltin"),
+            },
+        }
+    }
+
+    fn emit<I, const N: usize>(
+        &mut self,
+        builtin: RuntimeBuiltin,
+        args: mir::ArgsId,
+        result_ty: Option<SonaType>,
+        kind: OutputKind,
+        make: impl FnOnce(&dyn HasInst<I>, [SonaValueId; N]) -> I,
+    ) -> BuiltinOutput
+    where
+        I: Inst,
+        EvmInstSet: HasInst<I>,
+    {
+        let args = self.arg_values(builtin, args);
+        let inst = make(self.is, args);
+        match kind {
+            OutputKind::Value => BuiltinOutput::Value(
+                self.fb.insert_inst(inst, result_ty.expect("builtin should produce a value")),
+            ),
+            OutputKind::NoValue => {
+                self.fb.insert_inst_no_result(inst);
+                BuiltinOutput::NoValue
+            }
+            OutputKind::Terminator => {
+                self.fb.insert_inst_no_result(inst);
+                BuiltinOutput::Terminator
+            }
+        }
+    }
+
+    fn alloc(
+        &mut self,
+        builtin: RuntimeBuiltin,
+        args: mir::ArgsId,
+        result_ty: Option<SonaType>,
+        zeroed: bool,
+    ) -> BuiltinOutput {
+        let [size] = self.arg_values(builtin, args);
+        let result_ty = result_ty.expect("builtin should produce a value");
+        BuiltinOutput::Value({
+            let ptr_ty = self.fb.ptr_type(SonaType::I8);
+            let ptr = self.fb.insert_inst(EvmMalloc::new(self.is, size), ptr_ty);
+            if zeroed {
+                let data_offset = self.i256_inst(EvmCalldataSize::new(self.is));
+                self.fb.insert_inst_no_result(EvmCalldataCopy::new(
+                    self.is,
+                    ptr,
+                    data_offset,
+                    size,
+                ));
+            }
+            self.fb.insert_inst(PtrToInt::new(self.is, ptr, SonaType::I256), result_ty)
+        })
+    }
+
+    fn arg_values<const N: usize>(
+        &mut self,
+        builtin: RuntimeBuiltin,
+        args: mir::ArgsId,
+    ) -> [SonaValueId; N] {
+        let args = &self.mir.args[args];
+        assert_eq!(args.len(), N, "{builtin} expects {N} arguments, got {}", args.len());
+        let mut values = [SonaValueId(0); N];
+        for (value, arg) in values.iter_mut().zip(args) {
+            *value = self.read_value(*arg);
+        }
+        values
+    }
+
+    fn i256_inst<I>(&mut self, inst: I) -> SonaValueId
+    where
+        I: Inst,
+        EvmInstSet: HasInst<I>,
+    {
+        self.fb.insert_inst(inst, SonaType::I256)
+    }
+}

--- a/plankc/frontend/mir-lower-sona/src/lib.rs
+++ b/plankc/frontend/mir-lower-sona/src/lib.rs
@@ -1,0 +1,80 @@
+mod function;
+mod module;
+
+#[cfg(test)]
+mod tests;
+
+use plank_mir::Mir;
+use plank_values::ValueInterner;
+use sonatina_codegen::EvmCompile;
+pub use sonatina_codegen::OptLevel;
+use sonatina_ir::{Module, ir_writer::ModuleWriter, isa::evm::Evm, object::SectionName};
+use sonatina_triple::{Architecture, EvmVersion, OperatingSystem, TargetTriple, Vendor};
+use std::fmt;
+
+pub(crate) const CONTRACT_OBJECT: &str = "Contract";
+pub(crate) const INIT_SECTION: &str = "init";
+pub(crate) const RUNTIME_SECTION: &str = "runtime";
+
+#[derive(Debug, thiserror::Error)]
+pub enum LowerError {
+    #[error("Sonatina builder error: {0}")]
+    Builder(String),
+    #[error("Sonatina object compilation failed: {0}")]
+    ObjectCompile(String),
+}
+
+pub fn lower(isa: &Evm, mir: &Mir, values: &ValueInterner) -> Result<Module, LowerError> {
+    module::lower(isa, mir, values)
+}
+
+fn default_isa() -> Evm {
+    Evm::new(TargetTriple::new(
+        Architecture::Evm,
+        Vendor::Ethereum,
+        OperatingSystem::Evm(EvmVersion::Osaka),
+    ))
+}
+
+pub fn emit_ir(
+    mir: &Mir,
+    values: &ValueInterner,
+    opt_level: OptLevel,
+) -> Result<String, LowerError> {
+    let isa = default_isa();
+    let module = lower(&isa, mir, values)?;
+    let mut compile = EvmCompile::new(module).with_opt_level(opt_level);
+    Ok(ModuleWriter::new(compile.optimize()).dump_string())
+}
+
+pub fn emit_bytecode(
+    mir: &Mir,
+    values: &ValueInterner,
+    opt_level: OptLevel,
+) -> Result<Vec<u8>, LowerError> {
+    let isa = default_isa();
+    let module = lower(&isa, mir, values)?;
+    let artifact = EvmCompile::new(module)
+        .with_opt_level(opt_level)
+        .compile()
+        .map_err(|errors| object_compile_error(&errors))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| LowerError::ObjectCompile("no objects compiled".into()))?;
+    let init = SectionName::from(INIT_SECTION);
+    artifact
+        .sections
+        .get(&init)
+        .map(|section| section.bytes.clone())
+        .ok_or_else(|| LowerError::ObjectCompile("compiled object has no init section".into()))
+}
+
+pub(crate) fn builder_error(error: impl fmt::Display) -> LowerError {
+    LowerError::Builder(error.to_string())
+}
+
+fn object_compile_error(errors: &[impl fmt::Debug]) -> LowerError {
+    LowerError::ObjectCompile(
+        errors.iter().map(|err| format!("{err:?}")).collect::<Vec<_>>().join("; "),
+    )
+}

--- a/plankc/frontend/mir-lower-sona/src/module.rs
+++ b/plankc/frontend/mir-lower-sona/src/module.rs
@@ -1,0 +1,116 @@
+use crate::{
+    CONTRACT_OBJECT, INIT_SECTION, LowerError, RUNTIME_SECTION, builder_error,
+    function::FunctionLowerer,
+};
+use plank_core::{DenseIndexMap, Idx};
+use plank_mir::Mir;
+use plank_values::{PrimitiveType, Type as PlankType, TypeId, ValueInterner};
+use sonatina_ir::{
+    Linkage, Module, Signature, Type as SonaType,
+    builder::{ModuleBuilder, ObjectBuilder},
+    isa::{Isa, evm::Evm},
+    module::ModuleCtx,
+};
+use std::collections::HashMap;
+
+pub(crate) type RuntimeShapes = HashMap<TypeId, Option<SonaType>>;
+
+pub(crate) fn runtime_shape(shapes: &RuntimeShapes, ty: TypeId) -> Option<SonaType> {
+    *shapes.get(&ty).expect("type was not declared before lowering")
+}
+
+fn declare_runtime_shape(
+    shapes: &mut RuntimeShapes,
+    mir: &Mir,
+    builder: &ModuleBuilder,
+    ty: TypeId,
+) -> Option<SonaType> {
+    if let Some(&shape) = shapes.get(&ty) {
+        return shape;
+    }
+    let shape = match mir.types.lookup(ty) {
+        PlankType::Primitive(primitive) => match primitive {
+            PrimitiveType::Void | PrimitiveType::Never => None,
+            PrimitiveType::Bool => Some(SonaType::I1),
+            PrimitiveType::U256 | PrimitiveType::MemoryPointer => Some(SonaType::I256),
+            PrimitiveType::Function | PrimitiveType::Type => {
+                panic!("comptime-only type in MIR: {primitive:?}")
+            }
+        },
+        PlankType::Struct(struct_) => {
+            let field_shapes = struct_
+                .fields
+                .iter()
+                .map(|field| declare_runtime_shape(shapes, mir, builder, field.ty))
+                .collect::<Vec<_>>();
+            if field_shapes.iter().all(Option::is_none) {
+                None
+            } else {
+                let field_tys =
+                    field_shapes.iter().map(|s| s.unwrap_or(SonaType::Unit)).collect::<Vec<_>>();
+                Some(builder.declare_struct_type(
+                    &format!("struct_{}", ty.get()),
+                    &field_tys,
+                    false,
+                ))
+            }
+        }
+    };
+    shapes.insert(ty, shape);
+    shape
+}
+
+pub(crate) fn lower(isa: &Evm, mir: &Mir, values: &ValueInterner) -> Result<Module, LowerError> {
+    let is = isa.inst_set();
+    let mut builder = ModuleBuilder::new(ModuleCtx::new(isa));
+    let mut runtime_shapes = RuntimeShapes::new();
+    let mut funcs = DenseIndexMap::with_capacity(mir.fns.len());
+
+    // Declare runtime shapes before function signatures so aggregate type refs exist.
+    for fn_id in mir.fns.iter_idx() {
+        for &ty in &mir.fn_locals[fn_id] {
+            declare_runtime_shape(&mut runtime_shapes, mir, &builder, ty);
+        }
+        declare_runtime_shape(&mut runtime_shapes, mir, &builder, mir.fns[fn_id].return_type);
+    }
+
+    // Declare all functions before bodies so calls can reference any MIR function.
+    for fn_id in mir.fns.iter_idx() {
+        let def = mir.fns[fn_id];
+        let mut args = Vec::new();
+        for param in def.iter_params() {
+            args.extend(runtime_shape(&runtime_shapes, mir.fn_locals[fn_id][param.idx()]));
+        }
+        let returns: Vec<_> = runtime_shape(&runtime_shapes, def.return_type).into_iter().collect();
+
+        let (name, linkage) = if fn_id == mir.init {
+            ("init".to_string(), Linkage::Public)
+        } else if Some(fn_id) == mir.run {
+            ("run".to_string(), Linkage::Public)
+        } else {
+            (format!("fn_{}", fn_id.idx()), Linkage::Private)
+        };
+
+        let func = builder
+            .declare_function(Signature::new(&name, linkage, &args, &returns))
+            .map_err(builder_error)?;
+        funcs.insert(fn_id, func);
+    }
+
+    // Lower bodies after declarations so recursive and forward calls are valid.
+    for fn_id in mir.fns.iter_idx() {
+        FunctionLowerer::new(&builder, is, mir, values, &funcs, &runtime_shapes, fn_id).lower();
+    }
+
+    // Build the EVM object last so init can embed the completed runtime section.
+    let mut object = ObjectBuilder::new(CONTRACT_OBJECT);
+    if let Some(run) = mir.run {
+        object.section(RUNTIME_SECTION).entry(funcs[run]);
+    }
+    let init = object.section(INIT_SECTION).entry(funcs[mir.init]);
+    if mir.run.is_some() {
+        init.embed_local(RUNTIME_SECTION, RUNTIME_SECTION);
+    }
+    object.declare(&mut builder).map_err(builder_error)?;
+    Ok(builder.build())
+}

--- a/plankc/frontend/mir-lower-sona/src/tests.rs
+++ b/plankc/frontend/mir-lower-sona/src/tests.rs
@@ -1,0 +1,443 @@
+use crate::OptLevel;
+use plank_session::Session;
+use plank_test_utils::TestProject;
+use plank_values::ValueInterner;
+
+fn lower_ir(source: &str) -> String {
+    let mut session = Session::new();
+    let project = TestProject::root(source).build(&mut session);
+    let mut values = ValueInterner::new();
+    let hir = plank_hir::lower(&project, &mut values, &mut session);
+    let mir = plank_hir_eval::evaluate(&hir, project.core_ops_source, &mut values, &mut session);
+    assert!(!session.has_errors());
+    crate::emit_ir(&mir, &values, OptLevel::O0).unwrap()
+}
+
+fn lower_bytecode(source: &str) -> Vec<u8> {
+    let mut session = Session::new();
+    let project = TestProject::root(source).build(&mut session);
+    let mut values = ValueInterner::new();
+    let hir = plank_hir::lower(&project, &mut values, &mut session);
+    let mir = plank_hir_eval::evaluate(&hir, project.core_ops_source, &mut values, &mut session);
+    assert!(!session.has_errors());
+    crate::emit_bytecode(&mir, &values, OptLevel::O0).unwrap()
+}
+
+#[track_caller]
+fn assert_contains(haystack: &str, needle: &str) {
+    assert!(haystack.contains(needle), "expected IR to contain `{needle}`\n\n{haystack}");
+}
+
+#[track_caller]
+fn assert_lowers_to_ir(source: &str, expected: &str) {
+    let actual = lower_ir(source);
+    let expected = plank_test_utils::dedent_preserve_blank_lines(expected);
+    pretty_assertions::assert_str_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn lowers_simple_init_stop_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        init {
+            @evm_stop();
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func public %init() {
+            block0:
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_builtin_dataflow_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        init {
+            let value = @evm_calldataload(0);
+            let sum = @evm_add(value, 1);
+            @evm_sstore(2, sum);
+            @evm_stop();
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func public %init() {
+            block0:
+                v1.i256 = evm_calldata_load 0.i256;
+                v3.i256 = add v1 1.i256;
+                evm_sstore 2.i256 v3;
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_call_with_args_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        const safe_add = fn (x: u256, y: u256) u256 {
+            let z = @evm_add(x, y);
+            z
+        };
+
+        init {
+            let ptr = @malloc_uninit(32);
+            let z = safe_add(3, 4);
+            @mstore32(ptr, z);
+            @evm_stop();
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func private %fn_0(v0.i256, v1.i256) -> i256 {
+            block0:
+                v2.i256 = add v0 v1;
+                return v2;
+        }
+
+        func public %init() {
+            block0:
+                v1.*i8 = evm_malloc 32.i256;
+                v2.i256 = ptr_to_int v1 i256;
+                v5.i256 = call %fn_0 3.i256 4.i256;
+                mstore v2 v5 i256;
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_terminal_if_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        init {
+            let value = @evm_calldataload(0);
+            if @evm_gt(value, 0) {
+                @evm_stop();
+            } else {
+                @evm_revert(@malloc_uninit(0), 0);
+            }
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func public %init() {
+            block0:
+                v1.i256 = evm_calldata_load 0.i256;
+                v2.i1 = gt v1 0.i256;
+                br v2 block2 block1;
+
+            block1:
+                v3.*i8 = evm_malloc 0.i256;
+                v4.i256 = ptr_to_int v3 i256;
+                evm_revert v4 0.i256;
+
+            block2:
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_runtime_object_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        init {
+            let ptr = @malloc_uninit(32);
+            @mstore32(ptr, @runtime_start_offset());
+            @evm_return(ptr, @runtime_length());
+        }
+
+        run {
+            @evm_stop();
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func public %init() {
+            block0:
+                v1.*i8 = evm_malloc 32.i256;
+                v2.i256 = ptr_to_int v1 i256;
+                v3.i256 = sym_addr &runtime;
+                mstore v2 v3 i256;
+                v4.i256 = sym_size &runtime;
+                evm_return v2 v4;
+        }
+
+        func public %run() {
+            block0:
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section runtime {
+                entry %run;
+            }
+            section init {
+                entry %init;
+                embed .runtime as &runtime;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_aggregate_access_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        const Pair = struct { a: u256, empty: void, b: u256 };
+
+        init {
+            let pair = Pair { a: @evm_calldataload(0), empty: {}, b: @evm_calldataload(32) };
+            let ptr = @malloc_uninit(32);
+            @mstore32(ptr, pair.b);
+            @evm_return(ptr, 32);
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        type @struct_0 = {i256, unit, i256};
+
+        func public %init() {
+            block0:
+                v1.i256 = evm_calldata_load 0.i256;
+                v3.i256 = evm_calldata_load 32.i256;
+                v5.@struct_0 = insert_value undef.@struct_0 0.i256 v1;
+                v7.@struct_0 = insert_value v5 2.i256 v3;
+                v8.*i8 = evm_malloc 32.i256;
+                v9.i256 = ptr_to_int v8 i256;
+                v10.i256 = extract_value v7 2.i256;
+                mstore v9 v10 i256;
+                evm_return v9 32.i256;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_zero_runtime_struct_to_exact_ir() {
+    assert_lowers_to_ir(
+        r#"
+        const Empty = struct {};
+
+        init {
+            let empty = Empty {};
+            let copy = empty;
+            @evm_stop();
+        }
+        "#,
+        r#"
+        target = "evm-ethereum-osaka"
+
+        func public %init() {
+            block0:
+                evm_stop;
+        }
+
+
+        object @Contract {
+            section init {
+                entry %init;
+            }
+        }
+        "#,
+    );
+}
+
+#[test]
+fn lowers_signextend_and_partial_memory_helpers() {
+    let ir = lower_ir(
+        r#"
+        init {
+            let ptr = @malloc_uninit(32);
+            let byte = @evm_calldataload(0);
+            let value = @evm_calldataload(32);
+            let signed = @evm_signextend(byte, value);
+            @mstore1(ptr, signed);
+            let loaded = @mload3(ptr);
+            @mstore2(ptr, loaded);
+            @evm_stop();
+        }
+        "#,
+    );
+
+    assert_contains(&ir, "evm_signextend");
+    assert_contains(&ir, "mstore8");
+    assert_contains(&ir, "mload");
+    assert_contains(&ir, "shr");
+    assert_contains(&ir, "mstore");
+}
+
+#[test]
+fn lowers_runtime_introspection_symbols() {
+    let ir = lower_ir(
+        r#"
+        init {
+            let ptr = @malloc_uninit(96);
+            @mstore32(ptr, @runtime_start_offset());
+            @mstore32(@evm_add(ptr, 32), @runtime_length());
+            @mstore32(@evm_add(ptr, 64), @init_end_offset());
+            @evm_return(ptr, @runtime_length());
+        }
+
+        run {
+            @evm_stop();
+        }
+        "#,
+    );
+
+    assert_contains(&ir, "sym_addr &runtime");
+    assert_contains(&ir, "sym_size &runtime");
+    assert_contains(&ir, "sym_size .");
+}
+
+#[test]
+fn lowers_bool_builtins_as_i1_without_zext() {
+    let ir = lower_ir(
+        r#"
+        init {
+            let value = @evm_calldataload(0);
+            if @evm_gt(value, 0) {
+                @evm_stop();
+            } else {
+                @evm_stop();
+            }
+        }
+        "#,
+    );
+
+    assert_contains(&ir, " = gt ");
+    assert!(!ir.contains(" = zext "), "bool lowering should not widen through zext\n\n{ir}");
+    assert!(
+        !ir.contains(" = ne "),
+        "bool branch conditions should stay i1 instead of comparing a word to zero\n\n{ir}"
+    );
+    assert!(!ir.contains("evm_invalid"), "terminal if should not emit unreachable invalid\n\n{ir}");
+}
+
+#[test]
+fn lowers_structs_as_sonatina_aggregates() {
+    let ir = lower_ir(
+        r#"
+        const Pair = struct { a: u256, b: u256 };
+
+        init {
+            let pair = Pair { a: @evm_calldataload(0), b: @evm_calldataload(32) };
+            let pair_copy = pair;
+            let ptr = @malloc_uninit(32);
+            @mstore32(ptr, pair_copy.b);
+            @evm_return(ptr, 32);
+        }
+        "#,
+    );
+
+    assert_contains(&ir, "insert_value");
+    assert_contains(&ir, "extract_value");
+    assert!(ir.contains("type @struct_"), "expected a declared aggregate type\n\n{ir}");
+}
+
+#[test]
+fn lowers_zero_runtime_structs_without_aggregate_values() {
+    let ir = lower_ir(
+        r#"
+        const Empty = struct {};
+
+        init {
+            let empty = Empty {};
+            let copy = empty;
+            @evm_stop();
+        }
+        "#,
+    );
+
+    assert!(
+        !ir.contains("type @struct_"),
+        "zero-runtime struct should not declare an aggregate type\n\n{ir}"
+    );
+    assert!(
+        !ir.contains("insert_value"),
+        "zero-runtime struct should not construct an aggregate\n\n{ir}"
+    );
+}
+
+#[test]
+fn lowers_zeroed_allocation_with_calldatacopy() {
+    let ir = lower_ir(
+        r#"
+        init {
+            let zeroed = @malloc_zeroed(32);
+            @malloc_uninit(32);
+            @mstore32(zeroed, 1);
+            @evm_stop();
+        }
+        "#,
+    );
+
+    assert_contains(&ir, "evm_malloc");
+    assert_contains(&ir, "evm_calldata_size");
+    assert_contains(&ir, "evm_calldata_copy");
+}
+
+#[test]
+fn emits_bytecode_for_simple_program() {
+    let bytecode = lower_bytecode(
+        r#"
+        init {
+            @evm_stop();
+        }
+        "#,
+    );
+
+    assert!(!bytecode.is_empty());
+}

--- a/plankc/justfile
+++ b/plankc/justfile
@@ -14,15 +14,17 @@ test-sir-diff:
      forge test --ffi
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff: test-plank-diff-unoptimized test-plank-diff-optimized
+test-plank-diff: test-plank-diff-sir test-plank-diff-sona
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff-unoptimized:
-     PLANK_OPTIMIZE= forge test --ffi
+test-plank-diff-sir:
+     PLANK_BACKEND=sir PLANK_OPTIMIZE= forge test --ffi
+     PLANK_BACKEND=sir PLANK_OPTIMIZE=csud forge test --ffi
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff-optimized:
-     PLANK_OPTIMIZE=csud forge test --ffi
+test-plank-diff-sona:
+     PLANK_BACKEND=sona PLANK_OPTIMIZE= forge test --ffi
+     PLANK_BACKEND=sona PLANK_OPTIMIZE=O1 forge test --ffi
 
 test-all: test test-sir-diff test-plank-diff
 

--- a/plankc/plank-diff-tests/test/BaseTest.sol
+++ b/plankc/plank-diff-tests/test/BaseTest.sol
@@ -46,10 +46,11 @@ abstract contract BaseTest is Test {
     }
 
     function plank(string memory sourcePath) internal returns (bytes memory) {
+        string memory backend = vm.envOr("PLANK_BACKEND", string("sir"));
         string memory optimize = vm.envOr("PLANK_OPTIMIZE", string(""));
         bool hasOptimize = bytes(optimize).length != 0;
 
-        string[] memory args = new string[](hasOptimize ? 11 : 9);
+        string[] memory args = new string[](hasOptimize ? 13 : 11);
         args[0] = "cargo";
         args[1] = "run";
         args[2] = "-p";
@@ -57,11 +58,13 @@ abstract contract BaseTest is Test {
         args[4] = "--";
         args[5] = "build";
         args[6] = sourcePath;
-        args[7] = "--dep";
-        args[8] = string.concat("std=", vm.projectRoot(), "/../../std");
+        args[7] = "--backend";
+        args[8] = backend;
+        args[9] = "--dep";
+        args[10] = string.concat("std=", vm.projectRoot(), "/../../std");
         if (hasOptimize) {
-            args[9] = "-O";
-            args[10] = optimize;
+            args[11] = "-O";
+            args[12] = optimize;
         }
         return vm.ffi(args);
     }


### PR DESCRIPTION
Adds an alternative backend, enabled on the cli like so:
`plank build --backend sona -O1`

Optimization level defaults to `-O0`. `-O1` takes a little longer and generates significantly better bytecode; `-O2` is a *lot* slower, and modestly improves bytecode relative to `-O1`.

Code was initially generated by ai, followed by manual and ai-assisted refinement.