### PR TITLE
CI: run plank diff tests with and without optimizations

### DIFF
--- a/plankc/justfile
+++ b/plankc/justfile
@@ -15,7 +15,16 @@ test-sir-diff:
 
 [working-directory: 'plank-diff-tests/']
 test-plank-diff *args:
-     forge test --ffi {{args}}
+     PLANK_OPTIMIZE= forge test --ffi {{args}}
+     PLANK_OPTIMIZE=csud forge test --ffi {{args}}
+
+[working-directory: 'plank-diff-tests/']
+test-plank-diff-unoptimized *args:
+     PLANK_OPTIMIZE= forge test --ffi {{args}}
+
+[working-directory: 'plank-diff-tests/']
+test-plank-diff-optimized *args:
+     PLANK_OPTIMIZE=csud forge test --ffi {{args}}
 
 test-all: test test-sir-diff test-plank-diff
 
@@ -33,4 +42,3 @@ docs-build:
 
 docs-serve:
     mdbook serve ../plank-doc
-

--- a/plankc/justfile
+++ b/plankc/justfile
@@ -14,17 +14,15 @@ test-sir-diff:
      forge test --ffi
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff *args:
-     PLANK_OPTIMIZE= forge test --ffi {{args}}
-     PLANK_OPTIMIZE=csud forge test --ffi {{args}}
+test-plank-diff: test-plank-diff-unoptimized test-plank-diff-optimized
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff-unoptimized *args:
-     PLANK_OPTIMIZE= forge test --ffi {{args}}
+test-plank-diff-unoptimized:
+     PLANK_OPTIMIZE= forge test --ffi
 
 [working-directory: 'plank-diff-tests/']
-test-plank-diff-optimized *args:
-     PLANK_OPTIMIZE=csud forge test --ffi {{args}}
+test-plank-diff-optimized:
+     PLANK_OPTIMIZE=csud forge test --ffi
 
 test-all: test test-sir-diff test-plank-diff
 

--- a/plankc/plank-diff-tests/test/BaseTest.sol
+++ b/plankc/plank-diff-tests/test/BaseTest.sol
@@ -46,7 +46,10 @@ abstract contract BaseTest is Test {
     }
 
     function plank(string memory sourcePath) internal returns (bytes memory) {
-        string[] memory args = new string[](9);
+        string memory optimize = vm.envOr("PLANK_OPTIMIZE", string(""));
+        bool hasOptimize = bytes(optimize).length != 0;
+
+        string[] memory args = new string[](hasOptimize ? 11 : 9);
         args[0] = "cargo";
         args[1] = "run";
         args[2] = "-p";
@@ -56,6 +59,10 @@ abstract contract BaseTest is Test {
         args[6] = sourcePath;
         args[7] = "--dep";
         args[8] = string.concat("std=", vm.projectRoot(), "/../../std");
+        if (hasOptimize) {
+            args[9] = "-O";
+            args[10] = optimize;
+        }
         return vm.ffi(args);
     }
 }

--- a/plankc/sir/crates/debug-backend/src/static_memory_layout.rs
+++ b/plankc/sir/crates/debug-backend/src/static_memory_layout.rs
@@ -33,8 +33,11 @@ impl StaticMemoryLayout {
         let switch_store = next_free.alloc_bytes(EVM_WORD_IN_BYTES);
         let free_pointer = next_free.alloc_bytes(EVM_WORD_IN_BYTES);
 
-        let max_locals_transfer =
-            ir.blocks().map(|b| b.outputs().len() as u32).max().expect("at least 1 bb in valid IR");
+        let max_locals_transfer = ir
+            .blocks()
+            .map(|b| (b.outputs().len() as u32).max(b.inputs().len() as u32))
+            .max()
+            .expect("at least 1 bb in valid IR");
         let basic_block_locals_transfer =
             next_free.alloc_bytes(max_locals_transfer * EVM_WORD_IN_BYTES);
 


### PR DESCRIPTION
This reveals a bug in optimized sir triggered by the FixedBytes test added in #189