### PR TITLE
chore: address clippy nits

### DIFF
--- a/plankc/Cargo.lock
+++ b/plankc/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
 name = "plank"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "anstream",
  "clap",
  "owo-colors",

--- a/plankc/crates/plank-core/src/chunked_arena.rs
+++ b/plankc/crates/plank-core/src/chunked_arena.rs
@@ -129,8 +129,9 @@ impl<const ALIGN: usize, A: Allocator> ChunkedArena<ALIGN, A> {
                 .unwrap_or_else(|AllocError| handle_alloc_error(layout))
                 .cast();
             let prev_ptr = self.chunks[chunk_index as usize].replace(Some(new_ptr));
-            #[cfg(debug_assertions)]
-            if let Some(prev_ptr) = prev_ptr {
+            if cfg!(debug_assertions)
+                && let Some(prev_ptr) = prev_ptr
+            {
                 self.alloc.deallocate(prev_ptr, layout);
                 unreachable!("invariant: chunk reallocated");
             }

--- a/plankc/frontend/cli/Cargo.toml
+++ b/plankc/frontend/cli/Cargo.toml
@@ -14,6 +14,7 @@ plank-parser.workspace = true
 plank-source.workspace = true
 plank-hir.workspace = true
 plank-mir.workspace = true
+alloy-primitives.workspace = true
 sir-passes.workspace = true
 clap.workspace = true
 anstream.workspace = true

--- a/plankc/frontend/cli/src/main.rs
+++ b/plankc/frontend/cli/src/main.rs
@@ -263,9 +263,5 @@ fn build(plank_dir: Option<PathBuf>, args: BuildArgs) {
         )
         .unwrap_or_else(|err| cli_error_and_exit(err));
 
-    print!("0x");
-    for byte in bytecode {
-        print!("{:02x}", byte);
-    }
-    println!();
+    println!("{}", alloy_primitives::hex::display(bytecode));
 }


### PR DESCRIPTION
This applies small cleanup from the current compiler changes: it uses the shared Alloy hex display helper for CLI bytecode output and collapses the debug-only arena reallocation guard into a single conditional.