### PR TITLE
🐞 fix: if/else type mismatch causing cascading errors

### DIFF
--- a/plankc/frontend/hir-eval/src/functions/mod.rs
+++ b/plankc/frontend/hir-eval/src/functions/mod.rs
@@ -25,10 +25,10 @@ struct PreambleResult {
 }
 
 impl PreambleResult {
-    /// Helper to get outcome of a poisoned call
-    /// Diverges in case of a never-returning function to prevent error cascades
-    fn propagate_call_poison(&self) -> MaybePoisoned<Diverge> {
-        if self.return_type == Ok(TypeId::NEVER) { Ok(Diverge::END) } else { Err(Poisoned) }
+    fn suppress_poison_iff_diverging_return_type(
+        &self,
+    ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
+        if self.return_type == Ok(TypeId::NEVER) { Ok(Err(Diverge::END)) } else { Err(Poisoned) }
     }
 }
 
@@ -399,7 +399,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         };
         let lowered = match lowered {
             Ok(lowered) => lowered,
-            Err(Poisoned) => return preamble.propagate_call_poison().map(Err),
+            Err(Poisoned) => return preamble.suppress_poison_iff_diverging_return_type(),
         };
 
         let (mir_args, validity) = self.eval.mir_args.push_with_res(|mut pusher| {
@@ -427,7 +427,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             Ok(())
         });
         if let Err(Poisoned) = validity {
-            return preamble.propagate_call_poison().map(Err);
+            return preamble.suppress_poison_iff_diverging_return_type();
         }
 
         let expr = mir::Expr::Call { callee: lowered, args: mir_args };
@@ -462,8 +462,9 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 State::Done(value) => {
                     return match value {
                         Ok(value) => Ok(Ok(EvalValue::Comptime(value))),
-                        // Cache collapses `Diverge` into `Err(Poisoned)`.
-                        Err(Poisoned) => preamble.propagate_call_poison().map(Err),
+                        // Cache collapses `Diverge` into Err(Poisoned);
+                        // reconstruct the diverge when the return type was never.
+                        Err(Poisoned) => preamble.suppress_poison_iff_diverging_return_type(),
                     };
                 }
             },

--- a/plankc/frontend/hir-eval/src/functions/mod.rs
+++ b/plankc/frontend/hir-eval/src/functions/mod.rs
@@ -425,7 +425,11 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             Ok(())
         });
         if let Err(Poisoned) = validity {
-            return Err(Poisoned);
+            return if preamble.return_type == Ok(TypeId::NEVER) {
+                Ok(Err(Diverge::END))
+            } else {
+                Err(Poisoned)
+            };
         }
 
         let expr = mir::Expr::Call { callee: lowered, args: mir_args };

--- a/plankc/frontend/hir-eval/src/functions/mod.rs
+++ b/plankc/frontend/hir-eval/src/functions/mod.rs
@@ -24,6 +24,14 @@ struct PreambleResult {
     is_comptime_only: bool,
 }
 
+impl PreambleResult {
+    /// Helper to get outcome of a poisoned call
+    /// Diverges in case of a never-returning function to prevent error cascades
+    fn propagate_call_poison(&self) -> MaybePoisoned<Diverge> {
+        if self.return_type == Ok(TypeId::NEVER) { Ok(Diverge::END) } else { Err(Poisoned) }
+    }
+}
+
 struct Call<'a> {
     source: SourceId,
     caller_comptime: bool,
@@ -391,13 +399,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         };
         let lowered = match lowered {
             Ok(lowered) => lowered,
-            Err(Poisoned) => {
-                return if preamble.return_type == Ok(TypeId::NEVER) {
-                    Ok(Err(Diverge::END))
-                } else {
-                    Err(Poisoned)
-                };
-            }
+            Err(Poisoned) => return preamble.propagate_call_poison().map(Err),
         };
 
         let (mir_args, validity) = self.eval.mir_args.push_with_res(|mut pusher| {
@@ -425,11 +427,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             Ok(())
         });
         if let Err(Poisoned) = validity {
-            return if preamble.return_type == Ok(TypeId::NEVER) {
-                Ok(Err(Diverge::END))
-            } else {
-                Err(Poisoned)
-            };
+            return preamble.propagate_call_poison().map(Err);
         }
 
         let expr = mir::Expr::Call { callee: lowered, args: mir_args };
@@ -464,15 +462,8 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 State::Done(value) => {
                     return match value {
                         Ok(value) => Ok(Ok(EvalValue::Comptime(value))),
-                        Err(Poisoned) => {
-                            // Cache collapses `Diverge` into Err(Poisoned);
-                            // reconstruct the diverge when the return type was never.
-                            if preamble.return_type == Ok(TypeId::NEVER) {
-                                Ok(Err(Diverge::END))
-                            } else {
-                                Err(Poisoned)
-                            }
-                        }
+                        // Cache collapses `Diverge` into `Err(Poisoned)`.
+                        Err(Poisoned) => preamble.propagate_call_poison().map(Err),
                     };
                 }
             },

--- a/plankc/frontend/hir-eval/src/tests/calls.rs
+++ b/plankc/frontend/hir-eval/src/tests/calls.rs
@@ -767,6 +767,37 @@ fn test_comptime_diverge_prevents_cascade() {
 }
 
 #[test]
+fn test_if_arm_mismatch_into_never_call_prevents_cascade() {
+    assert_diagnostics(
+        r#"
+        const sink = fn(x: u256) never { @evm_stop(); };
+        const f = fn() never {
+            let c = @evm_calldataload(0);
+            let v = if @evm_iszero(c) {
+                1
+            } else {
+                false
+            };
+            sink(v);
+        };
+        init {
+            f();
+        }
+        "#,
+        &[r#"
+        error: `if` and `else` have incompatible types
+         --> main.plk:7:9
+          |
+        5 |         1
+          |         - `u256` expected because of this
+        6 |     } else {
+        7 |         false
+          |         ^^^^^ expected `u256`, got `bool`
+        "#],
+    );
+}
+
+#[test]
 fn test_runtime_comptime_only_arg() {
     assert_lowers_to(
         r#"

--- a/plankc/frontend/hir-eval/src/tests/calls.rs
+++ b/plankc/frontend/hir-eval/src/tests/calls.rs
@@ -769,11 +769,12 @@ fn test_comptime_diverge_prevents_cascade() {
 #[test]
 fn test_if_arm_mismatch_into_never_call_prevents_cascade() {
     assert_diagnostics(
-        r#"
+        std_project(
+            r#"
         const sink = fn(x: u256) never { @evm_stop(); };
         const f = fn() never {
             let c = @evm_calldataload(0);
-            let v = if @evm_iszero(c) {
+            let v = if c == 0 {
                 1
             } else {
                 false
@@ -784,6 +785,7 @@ fn test_if_arm_mismatch_into_never_call_prevents_cascade() {
             f();
         }
         "#,
+        ),
         &[r#"
         error: `if` and `else` have incompatible types
          --> main.plk:7:9
@@ -800,11 +802,12 @@ fn test_if_arm_mismatch_into_never_call_prevents_cascade() {
 #[test]
 fn test_if_arm_mismatch_into_non_never_call_preserves_poison() {
     assert_diagnostics(
-        r#"
+        std_project(
+            r#"
         const sink = fn(x: u256) u256 { x };
         const f = fn() void {
             let c = @evm_calldataload(0);
-            let v = if @evm_iszero(c) {
+            let v = if c == 0 {
                 1
             } else {
                 false
@@ -817,6 +820,7 @@ fn test_if_arm_mismatch_into_non_never_call_preserves_poison() {
             @evm_stop();
         }
         "#,
+        ),
         &[
             r#"
             error: `if` and `else` have incompatible types

--- a/plankc/frontend/hir-eval/src/tests/calls.rs
+++ b/plankc/frontend/hir-eval/src/tests/calls.rs
@@ -798,6 +798,50 @@ fn test_if_arm_mismatch_into_never_call_prevents_cascade() {
 }
 
 #[test]
+fn test_if_arm_mismatch_into_non_never_call_preserves_poison() {
+    assert_diagnostics(
+        r#"
+        const sink = fn(x: u256) u256 { x };
+        const f = fn() void {
+            let c = @evm_calldataload(0);
+            let v = if @evm_iszero(c) {
+                1
+            } else {
+                false
+            };
+            sink(v);
+            let bad: u256 = false;
+        };
+        init {
+            f();
+            @evm_stop();
+        }
+        "#,
+        &[
+            r#"
+            error: `if` and `else` have incompatible types
+             --> main.plk:7:9
+              |
+            5 |         1
+              |         - `u256` expected because of this
+            6 |     } else {
+            7 |         false
+              |         ^^^^^ expected `u256`, got `bool`
+            "#,
+            r#"
+            error: mismatched types
+              --> main.plk:10:21
+               |
+            10 |     let bad: u256 = false;
+               |              ----   ^^^^^ expected `u256`, got `bool`
+               |              |
+               |              `u256` expected because of this
+            "#,
+        ],
+    );
+}
+
+#[test]
 fn test_runtime_comptime_only_arg() {
     assert_lowers_to(
         r#"

--- a/plankc/frontend/hir-eval/src/tests/mod.rs
+++ b/plankc/frontend/hir-eval/src/tests/mod.rs
@@ -11,6 +11,12 @@ use plank_session::Session;
 use plank_test_utils::{TestProject, dedent_preserve_blank_lines};
 use plank_values::ValueInterner;
 
+const STD_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../std");
+
+fn std_project(source: &str) -> TestProject {
+    TestProject::root(source).with_stdlib_dir(STD_DIR)
+}
+
 fn try_lower(project: impl Into<TestProject>) -> (Mir, ValueInterner, Session) {
     let project = project.into();
     let mut session = Session::new();

--- a/plankc/frontend/hir-eval/src/tests/operators.rs
+++ b/plankc/frontend/hir-eval/src/tests/operators.rs
@@ -1,12 +1,6 @@
 use super::*;
 use plank_test_utils::TestProject;
 
-const STD_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../std");
-
-fn std_project(source: &str) -> TestProject {
-    TestProject::root(source).with_stdlib_dir(STD_DIR)
-}
-
 #[test]
 fn test_binary_op_not_supported_without_std() {
     assert_diagnostics(


### PR DESCRIPTION
Fixes #214 by ensuring poisoned arguments passed to `never`-returning functions emit a divergence (`Diverge::END`) instead of a poison.
  
Mirrors the existing handling ~10 lines above for the case where the callee *body* failed to lower also emits a (`Diverge::END`).

Added a simple test for the cascading errors
