### PR TITLE
Split critical edges in SIR CLI release mode

### DIFF
--- a/plankc/sir/crates/cli/src/main.rs
+++ b/plankc/sir/crates/cli/src/main.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
 use sir_parser::{EmitConfig, parse_or_panic};
-use sir_passes::{OPTIMIZE_HELP, PassManager, parse_optimizations_string};
+use sir_passes::{
+    AnalysesStore, OPTIMIZE_HELP, PassManager, parse_optimizations_string, run_pass,
+    transforms::CriticalEdgeSplitting,
+};
 use std::{
     fs,
     io::{self, Read},
@@ -67,13 +70,25 @@ fn main() {
     // Parse IR to EthIRProgram
     let mut program = parse_or_panic(&source, config);
 
-    let analyses = match cli.optimize {
-        Some(passes) => {
+    let analyses = if cli.release {
+        let store = AnalysesStore::default();
+        run_pass(&mut CriticalEdgeSplitting, &mut program, &store);
+        if let Some(passes) = cli.optimize {
             let mut pass_manager = PassManager::new(&mut program);
             pass_manager.run_optimizations(&passes);
             pass_manager.into_store()
+        } else {
+            AnalysesStore::default()
         }
-        None => sir_passes::AnalysesStore::default(),
+    } else {
+        match cli.optimize {
+            Some(passes) => {
+                let mut pass_manager = PassManager::new(&mut program);
+                pass_manager.run_optimizations(&passes);
+                pass_manager.into_store()
+            }
+            None => sir_passes::AnalysesStore::default(),
+        }
     };
 
     let mut bytecode = Vec::with_capacity(0x6000);

--- a/plankc/sir/crates/cli/tests/release_critical_edges.rs
+++ b/plankc/sir/crates/cli/tests/release_critical_edges.rs
@@ -1,0 +1,85 @@
+#![allow(unused_crate_dependencies)]
+
+use std::{
+    io::Write,
+    process::{Command, Output, Stdio},
+};
+
+const SIR_WITH_SHARED_REVERT_EDGE: &str = r#"
+fn init:
+    entry {
+        size = runtime_length
+        offset = runtime_start_offset
+        ptr = malloc size
+        codecopy ptr offset size
+        return ptr size
+    }
+
+fn main:
+    entry {
+        c0 = callvalue
+        => c0 ? @make_value : @revert_error
+    }
+    make_value {
+        x = const 0x2a
+        c1 = callvalue
+        => c1 ? @use_value : @return_zero
+    }
+    return_zero {
+        z = const 0x0
+        return z z
+    }
+    use_value {
+        y = add x x
+        c2 = callvalue
+        => c2 ? @return_value : @revert_error
+    }
+    return_value {
+        size = const 0x20
+        out = malloc size
+        mstore256 out y
+        return out size
+    }
+    revert_error {
+        zero = const 0x0
+        revert zero zero
+    }
+"#;
+
+fn run_sir(args: &[&str], input: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sir"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn sir CLI");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("sir CLI stdin")
+        .write_all(input.as_bytes())
+        .expect("write SIR to stdin");
+
+    child.wait_with_output().expect("wait for sir CLI")
+}
+
+#[test]
+fn release_splits_critical_edges_for_block_parameter_sir() {
+    let debug = run_sir(&[], SIR_WITH_SHARED_REVERT_EDGE);
+    assert!(
+        debug.status.success(),
+        "debug backend should accept fixture:\n{}",
+        String::from_utf8_lossy(&debug.stderr)
+    );
+
+    let release = run_sir(&["--release"], SIR_WITH_SHARED_REVERT_EDGE);
+    assert!(
+        release.status.success(),
+        "release backend should accept fixture after critical-edge splitting:\n{}",
+        String::from_utf8_lossy(&release.stderr)
+    );
+
+    assert!(String::from_utf8_lossy(&release.stdout).starts_with("0x"));
+}


### PR DESCRIPTION

## PR

Some valid block-parameter SIR accepted by the debug backend panics in the release backend stack scheduler.
Before this change, a reduced fixture (_also added as a test_) accepted by debug mode failed in release mode.

## Problem:

External producers such as Ora can already emit block-parameter SIR, so rerunning the full SSA transform is too broad. The missing release backend prerequisite is narrower, critical edges must be split before stack scheduling

## Proposed fix

For sir --release, run `CriticalEdgeSplitting` immediately after parsing and before optional optimisation passes / release codegen

_note: debug backend path remains unchanged_

Added an integration test with a reduced SIR fixture that:

1. compiles successfully in debug mode;
2. compiles successfully in release mode after critical-edge splitting;
3. previously reproduced the release stack-scheduler panic.

## Validation
```
  cargo test -p sir-cli --test release_critical_edges
  cargo test -p sir-cli
  cargo build --release -p sir-cli
```