### PR TITLE
Duplicated `ConstDef` should not be emitted into HIR

### DIFF
--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -904,30 +904,37 @@ fn register_consts(
 
     let mut seen = HashMap::new();
     for (id, source) in sources.enumerate_idx() {
+        let mut source_const_defs: Vec<ConstDef> = Vec::new();
         let file = source.cst.as_file();
         seen.clear();
         source_consts.push_with(|mut list| {
             for def in file.iter_defs() {
-                let TopLevelDef::Const(const_def) = def else { continue };
-                let source_span = source.lexed.tokens_src_span(const_def.span());
-                let const_id = consts.push(ConstDef {
-                    name: const_def.name,
+                let TopLevelDef::Const(const_decl) = def else { continue };
+                let source_span = source.lexed.tokens_src_span(const_decl.span());
+                let const_def = ConstDef {
+                    name: const_decl.name,
                     source_id: id,
                     source_span,
                     body: BlockId::ZERO,
                     result: LocalId::ZERO,
-                });
-                if let Some(prev) = seen.insert(const_def.name, const_id) {
+                };
+
+                if let Some(prev) = seen.insert(const_def.name, const_def) {
                     diagnostics::error_duplicate_const(
                         session,
                         id,
                         const_def.name,
                         source_span,
-                        &consts[prev],
+                        &prev,
                     );
                 } else {
-                    list.push((const_def.name, const_id));
+                    source_const_defs.push(const_def);
                 }
+            }
+
+            for const_def in source_const_defs.into_iter() {
+                let const_id = consts.push(const_def);
+                list.push((const_def.name, const_id));
             }
         });
     }

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -918,7 +918,6 @@ fn register_consts(
                     body: BlockId::ZERO,
                     result: LocalId::ZERO,
                 };
-
                 if let Some(prev) = seen.insert(const_def.name, const_def) {
                     diagnostics::error_duplicate_const(
                         session,
@@ -931,7 +930,6 @@ fn register_consts(
                     source_const_defs.push(const_def);
                 }
             }
-
             for const_def in source_const_defs.into_iter() {
                 let const_id = consts.push(const_def);
                 list.push((const_def.name, const_id));

--- a/plankc/frontend/hir/src/tests.rs
+++ b/plankc/frontend/hir/src/tests.rs
@@ -525,6 +525,83 @@ fn test_duplicate_const_def() {
 }
 
 #[test]
+fn test_duplicated_const_def_should_not_be_lowered_into_hir() {
+    let project = TestProject::root(
+        r#"
+        import m::other::f2;
+
+        const f1 = fn (comptime T: type) void {
+            f2;
+        };
+        init {}
+        "#,
+    )
+    .add_file(
+        "other",
+        r#"
+        const f2 = fn () void { };
+        const f2 = fn () void { };
+        "#,
+    )
+    .add_module("m", "");
+
+    let (hir, big_nums, session, _) = try_lower_project(project);
+
+    let rendered = format_session_diagnostics(&session);
+    let expected = dedent_preserve_blank_lines(
+        r#"
+        error: duplicate definition of 'f2'
+         --> other.plk:2:1
+          |
+        1 | const f2 = fn () void { };
+          | -------------------------- previously defined here
+        2 | const f2 = fn () void { };
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'f2' redefined here
+        "#,
+    );
+    pretty_assertions::assert_str_eq!(rendered.trim(), expected.trim());
+
+    let actual_hir = format!("{}", DisplayHir::new(&hir, &big_nums, &session));
+    let expected_hir = dedent_preserve_blank_lines(
+        r#"
+        ==== Constants ====
+        ConstId(0) ("f1") result=LocalId(0) {
+            %0 = @fn0
+        }
+        ConstId(1) ("f2") result=LocalId(0) {
+            %0 = @fn2
+        }
+
+        ==== Functions ====
+        @fn0(comptime %1: %0) -> %2 {
+            preamble:
+                %0 = type:type
+                [comptime] param#0 %1 : %0
+                %2 = type:void
+            body:
+                eval $1
+                ret void
+        }
+        @fn1() -> %0 {
+            preamble:
+                %0 = type:void
+            body:
+                ret void
+        }
+        @fn2() -> %0 {
+            preamble:
+                %0 = type:void
+            body:
+                ret void
+        }
+
+        ==== Init ====
+        "#,
+    );
+    pretty_assertions::assert_str_eq!(actual_hir.trim(), expected_hir.trim());
+}
+
+#[test]
 fn test_import_name_collision() {
     let project = TestProject::root(
         r#"


### PR DESCRIPTION
Fixes https://github.com/plankevm/plank-monorepo/issues/246

Duplicated const defs were being emitted into HIR during initial const registration, which caused corruption in subsequent  lowering. The fix ensures that const defs are only added to global consts and source-level consts after duplicates are filtered out.

Given scenario in https://github.com/plankevm/plank-monorepo/issues/246, HIR before fix:
```
==== Constants ====
ConstId(0) ("f1") result=LocalId(0) {
    %0 = @fn0
}
ConstId(1) ("f2") result=LocalId(0) {
    %0 = @fn2
}
ConstId(2) ("f2") result=LocalId(0) {
    %0 = type:type  <---- CORRUPTION: parameter list for function f1 was inserted here
    [comptime] param#0 %1 : %0
    %2 = type:void
}

==== Functions ====
@fn0(comptime %1: %0) -> %2 {
    preamble:
        %0 = type:type
        [comptime] param#0 %1 : %0
        %2 = type:void
    body:
        eval $1
        ret void
}
@fn1() -> %0 {
    preamble:
        %0 = type:void
    body:
        ret void
}
@fn2() -> %0 {
    preamble:
        %0 = type:void
    body:
        ret void
}

==== Init ====
```

After Fix:
```
==== Constants ====
ConstId(0) ("f1") result=LocalId(0) {
    %0 = @fn0
}
ConstId(1) ("f2") result=LocalId(0) {
    %0 = @fn2
}

==== Functions ====
@fn0(comptime %1: %0) -> %2 {
    preamble:
        %0 = type:type
        [comptime] param#0 %1 : %0
        %2 = type:void
    body:
        eval $1
        ret void
}
@fn1() -> %0 {   <----- Notable: dead code (object assigned to duplicated const that was filtered out)
    preamble:
        %0 = type:void
    body:
        ret void
}
@fn2() -> %0 {
    preamble:
        %0 = type:void
    body:
        ret void
}

==== Init ====
```