### PR TITLE
 Make `void` an alias for the empty `tuple {}` (#219)

### DIFF
--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -636,11 +636,6 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 });
                 target
             }
-            Type::Primitive(PrimitiveType::Void) => {
-                let target = self.mir_types.push(TypeId::VOID);
-                self.emit(mir::Instruction::Set { target, expr: mir::Expr::Const(ValueId::VOID) });
-                target
-            }
             Type::Primitive(
                 PrimitiveType::Type
                 | PrimitiveType::Function
@@ -857,7 +852,6 @@ fn build_uninit_comptime(
     match types.lookup(ty) {
         Type::Primitive(PrimitiveType::U256) => ValueId::ZERO_NUM,
         Type::Primitive(PrimitiveType::Bool) => ValueId::FALSE,
-        Type::Primitive(PrimitiveType::Void) => ValueId::VOID,
         Type::Primitive(PrimitiveType::Type) => values.intern_type(TypeId::VOID),
         Type::Primitive(PrimitiveType::CBytes) => ValueId::BYTES_EMPTY,
         Type::Primitive(

--- a/plankc/frontend/hir-eval/src/operators.rs
+++ b/plankc/frontend/hir-eval/src/operators.rs
@@ -289,8 +289,8 @@ impl crate::scope::Scope<'_, '_> {
                 let args = [lhs, rhs];
                 self.eval_runtime_foldable_builtin(RuntimeBuiltin::Eq, &args, expr)
             }
-            (op_equals, Ok(PrimitiveType::Void)) => {
-                // `(x: void) == (y: void)` is always `true`, `!=` always `false`.
+            (op_equals, Err(_)) if ty == TypeId::VOID => {
+                // `void` is the empty tuple: `() == ()` is always `true`, `!=` always `false`.
                 Ok(Ok(EvalValue::Comptime(op_equals.into())))
             }
             (false, Ok(PrimitiveType::U256 | PrimitiveType::MemoryPointer)) => {

--- a/plankc/frontend/hir-eval/src/tests/basic.rs
+++ b/plankc/frontend/hir-eval/src/tests/basic.rs
@@ -18,7 +18,7 @@ fn test_simple_malloc_mstore_return() {
             %1 : memptr = @malloc_uninit(%0)
             %2 : memptr = %1
             %3 : u256 = 5
-            %4 : void = @mstore32(%2, %3)
+            %4 : tuple {} = @mstore32(%2, %3)
             %5 : memptr = %1
             %6 : u256 = 32
             %7 : never = @evm_return(%5, %6)
@@ -61,13 +61,13 @@ fn test_no_else_if_as_expr() {
                 if %10 {
                     %11 : u256 = 3
                     %12 : u256 = 4
-                    %13 : void = @evm_sstore(%11, %12)
-                    %14 : void = void_unit
+                    %13 : tuple {} = @evm_sstore(%11, %12)
+                    %14 : tuple {} = ()
                 } else {
-                    %14 : void = void_unit
+                    %14 : tuple {} = ()
                 }
             }
-            %15 : void = %14
+            %15 : tuple {} = %14
             %16 : never = @evm_stop()
         }
         "#,
@@ -94,7 +94,7 @@ fn test_comptime_if_condition_folds_in_runtime() {
         @fn0() -> never {
             %0 : u256 = 3
             %1 : u256 = 4
-            %2 : void = @evm_sstore(%0, %1)
+            %2 : tuple {} = @evm_sstore(%0, %1)
             %3 : never = @evm_stop()
         }
         "#,
@@ -437,7 +437,7 @@ fn test_never_fn_missing_termination() {
           | |                     `never` expected because of this
         3 | |         let x = 5;
         4 | |     };
-          | |_____^ expected `never`, got `void`
+          | |_____^ expected `never`, got `tuple {}`
         "#],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/calls.rs
+++ b/plankc/frontend/hir-eval/src/tests/calls.rs
@@ -655,7 +655,7 @@ fn test_inconsistent_premable() {
           --> main.plk:5:38
            |
          5 | const weird = fn (comptime N: u256) (if even(N) { not_a_type } else { bool }) {
-           |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type, got value of type `void`
+           |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type, got value of type `tuple {}`
            |
         note: called here
           --> main.plk:11:20

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -2935,11 +2935,11 @@ fn scoped_set_eval_in_branch() {
             %0 : bool = false
             %1 : bool = %0
             if %1 {
-                %2 : void = void_unit
+                %2 : tuple {} = ()
             } else {
-                %2 : void = void_unit
+                %2 : tuple {} = ()
             }
-            %3 : void = %2
+            %3 : tuple {} = %2
             %4 : never = @evm_stop()
         }
         "#,

--- a/plankc/frontend/hir-eval/src/tests/operators.rs
+++ b/plankc/frontend/hir-eval/src/tests/operators.rs
@@ -43,7 +43,7 @@ fn test_unary_bitwise_not_without_std() {
             %3 : u256 = @evm_not(%2)
             %4 : u256 = %3
             %5 : u256 = 0
-            %6 : void = @evm_sstore(%5, %4)
+            %6 : tuple {} = @evm_sstore(%5, %4)
             %7 : never = @evm_stop()
         }
         "#,
@@ -92,12 +92,12 @@ fn test_runtime_checked_add_with_std() {
             %3 : u256 = 0
             %4 : memptr = @evm_add(%2, %3)
             %5 : u256 = 0x4e487b71
-            %6 : void = @mstore32(%4, %5)
+            %6 : tuple {} = @mstore32(%4, %5)
             %7 : memptr = %1
             %8 : u256 = 32
             %9 : memptr = @evm_add(%7, %8)
             %10 : u256 = 17
-            %11 : void = @mstore32(%9, %10)
+            %11 : tuple {} = @mstore32(%9, %10)
             %12 : memptr = %1
             %13 : u256 = 28
             %14 : memptr = @evm_add(%12, %13)
@@ -115,9 +115,9 @@ fn test_runtime_checked_add_with_std() {
             if %7 {
                 %8 : never = call @fn0()
             } else {
-                %9 : void = void_unit
+                %9 : tuple {} = ()
             }
-            %10 : void = %9
+            %10 : tuple {} = %9
             %11 : u256 = %4
             ret %11
         }
@@ -296,16 +296,16 @@ fn test_shift_operators() {
             %13 : u256 = @evm_shl(%12, %11)
             %14 : u256 = %4
             %15 : u256 = 0
-            %16 : void = @evm_sstore(%15, %14)
+            %16 : tuple {} = @evm_sstore(%15, %14)
             %17 : u256 = %7
             %18 : u256 = 1
-            %19 : void = @evm_sstore(%18, %17)
+            %19 : tuple {} = @evm_sstore(%18, %17)
             %20 : u256 = %10
             %21 : u256 = 2
-            %22 : void = @evm_sstore(%21, %20)
+            %22 : tuple {} = @evm_sstore(%21, %20)
             %23 : u256 = %13
             %24 : u256 = 3
-            %25 : void = @evm_sstore(%24, %23)
+            %25 : tuple {} = @evm_sstore(%24, %23)
             %26 : never = @evm_stop()
         }
         "#,
@@ -475,7 +475,7 @@ fn test_runtime_bitwise_not_with_std() {
             %3 : u256 = @evm_not(%2)
             %4 : u256 = %3
             %5 : u256 = 0
-            %6 : void = @evm_sstore(%5, %4)
+            %6 : tuple {} = @evm_sstore(%5, %4)
             %7 : never = @evm_stop()
         }
         "#,
@@ -500,7 +500,7 @@ fn test_comptime_checked_add_fold_with_std() {
         @fn0() -> never {
             %0 : u256 = 7
             %1 : u256 = 0
-            %2 : void = @evm_sstore(%0, %1)
+            %2 : tuple {} = @evm_sstore(%0, %1)
             %3 : never = @evm_stop()
         }
         "#,
@@ -525,7 +525,7 @@ fn test_comptime_wrapping_add_fold_with_std() {
         @fn0() -> never {
             %0 : u256 = 8
             %1 : u256 = 0
-            %2 : void = @evm_sstore(%0, %1)
+            %2 : tuple {} = @evm_sstore(%0, %1)
             %3 : never = @evm_stop()
         }
         "#,
@@ -552,10 +552,10 @@ fn test_comptime_shift_fold_with_std() {
         @fn0() -> never {
             %0 : u256 = 0
             %1 : u256 = 16
-            %2 : void = @evm_sstore(%0, %1)
+            %2 : tuple {} = @evm_sstore(%0, %1)
             %3 : u256 = 1
             %4 : u256 = 256
-            %5 : void = @evm_sstore(%3, %4)
+            %5 : tuple {} = @evm_sstore(%3, %4)
             %6 : never = @evm_stop()
         }
         "#,
@@ -714,7 +714,7 @@ fn test_equals_type_equality() {
         @fn0() -> never {
             %0 : u256 = 0
             %1 : u256 = 1
-            %2 : void = @evm_sstore(%0, %1)
+            %2 : tuple {} = @evm_sstore(%0, %1)
             %3 : never = @evm_stop()
         }
         "#,
@@ -946,9 +946,9 @@ fn test_memptr_equality() {
             if %5 {
                 %6 : never = @evm_invalid()
             } else {
-                %7 : void = void_unit
+                %7 : tuple {} = ()
             }
-            %8 : void = %7
+            %8 : tuple {} = %7
             %9 : never = @evm_stop()
         }
         "#,
@@ -1042,12 +1042,12 @@ fn test_operator_precedence() {
             %3 : u256 = 0
             %4 : memptr = @evm_add(%2, %3)
             %5 : u256 = 0x4e487b71
-            %6 : void = @mstore32(%4, %5)
+            %6 : tuple {} = @mstore32(%4, %5)
             %7 : memptr = %1
             %8 : u256 = 32
             %9 : memptr = @evm_add(%7, %8)
             %10 : u256 = 17
-            %11 : void = @mstore32(%9, %10)
+            %11 : tuple {} = @mstore32(%9, %10)
             %12 : memptr = %1
             %13 : u256 = 28
             %14 : memptr = @evm_add(%12, %13)
@@ -1072,9 +1072,9 @@ fn test_operator_precedence() {
             if %14 {
                 %15 : never = call @fn2()
             } else {
-                %16 : void = void_unit
+                %16 : tuple {} = ()
             }
-            %17 : void = %16
+            %17 : tuple {} = %16
             %18 : u256 = %4
             ret %18
         }
@@ -1098,12 +1098,12 @@ fn test_operator_precedence() {
             %3 : u256 = 0
             %4 : memptr = @evm_add(%2, %3)
             %5 : u256 = 0x4e487b71
-            %6 : void = @mstore32(%4, %5)
+            %6 : tuple {} = @mstore32(%4, %5)
             %7 : memptr = %1
             %8 : u256 = 32
             %9 : memptr = @evm_add(%7, %8)
             %10 : u256 = 18
-            %11 : void = @mstore32(%9, %10)
+            %11 : tuple {} = @mstore32(%9, %10)
             %12 : memptr = %1
             %13 : u256 = 28
             %14 : memptr = @evm_add(%12, %13)
@@ -1118,9 +1118,9 @@ fn test_operator_precedence() {
             if %4 {
                 %5 : never = call @fn6()
             } else {
-                %6 : void = void_unit
+                %6 : tuple {} = ()
             }
-            %7 : void = %6
+            %7 : tuple {} = %6
             %8 : u256 = %0
             %9 : u256 = %1
             %10 : u256 = @evm_div(%8, %9)
@@ -1137,9 +1137,9 @@ fn test_operator_precedence() {
             if %7 {
                 %8 : never = call @fn2()
             } else {
-                %9 : void = void_unit
+                %9 : tuple {} = ()
             }
-            %10 : void = %9
+            %10 : tuple {} = %9
             %11 : u256 = %4
             ret %11
         }

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use plank_core::Idx;
 use plank_session::{Session, write_bytes_literal};
-use plank_values::{U256, Value, ValueInterner, uint};
+use plank_values::{TypeId, U256, Value, ValueInterner, uint};
 use std::fmt::{self, Display, Formatter};
 
 const DISPLAY_AS_HEX_THRESHOLD: U256 = uint!(100_000_U256);
@@ -57,7 +57,6 @@ impl<'a> DisplayHir<'a> {
             Expr::Value(Err(Poisoned)) => write!(f, "<poison>"),
             Expr::Value(Ok(vid)) => match self.values.lookup(vid) {
                 Value::Bool(b) => write!(f, "{b}"),
-                Value::Void => write!(f, "void"),
                 Value::BigNum(x) => {
                     if x < DISPLAY_AS_HEX_THRESHOLD {
                         write!(f, "{x}")
@@ -65,17 +64,19 @@ impl<'a> DisplayHir<'a> {
                         write!(f, "0x{x:x}")
                     }
                 }
+                Value::Type(TypeId::VOID) => write!(f, "type:tuple {{}}"),
                 Value::Type(id) => write!(
                     f,
                     "type:{}",
                     id.as_primitive()
-                        .expect("invariant: only primitive types are inlined as HIR values")
+                        .expect("invariant: only primitive types and void are inlined as Value::Type in HIR")
                         .name()
                 ),
                 Value::Bytes(bytes) => {
                     let bytes = self.session.lookup_bytes_slice(bytes);
                     write_bytes_literal(f, bytes)
                 }
+                Value::Compound { ty, .. } if ty == TypeId::VOID => write!(f, "type:tuple {{}}"),
                 other @ (Value::Closure { .. } | Value::Compound { .. }) => {
                     unreachable!("unexpected value in HIR: {other:?}")
                 }

--- a/plankc/frontend/hir/src/tests.rs
+++ b/plankc/frontend/hir/src/tests.rs
@@ -117,14 +117,14 @@ fn test_inline_closure_lowering() {
                 %0 = type:never
             body:
                 eval @evm_stop()
-                ret void
+                ret type:tuple {}
         }
         @fn1() -> %0 {
             preamble:
                 %0 = type:never
             body:
                 eval @evm_invalid()
-                ret void
+                ret type:tuple {}
         }
         @fn2() -> %0 {
             captures: [%0 -> %1]
@@ -133,7 +133,7 @@ fn test_inline_closure_lowering() {
             body:
                 %2 = %1
                 eval call %2()
-                ret void
+                ret type:tuple {}
         }
 
         ==== Init ====
@@ -354,7 +354,7 @@ fn test_fn_struct_return() {
         r#"
         ==== Constants ====
         ConstId(0) ("Pair") result=LocalId(0) {
-            %1 = void
+            %1 = type:tuple {}
             %2 = type:u256
             %3 = type:u256
             %0 = struct#0 main.plk:1:14
@@ -1462,7 +1462,7 @@ fn test_explicit_return_in_function() {
                 %3 = %1
                 %4 = 1
                 ret @evm_add(%3, %4)
-                ret void
+                ret type:tuple {}
         }
 
         ==== Init ====

--- a/plankc/frontend/mir-lower-sona/src/function.rs
+++ b/plankc/frontend/mir-lower-sona/src/function.rs
@@ -374,7 +374,6 @@ impl<'a> FunctionLowerer<'a> {
 
     fn materialize_constant(&mut self, value: ValueId) -> Option<SonaValueId> {
         match self.values.lookup(value) {
-            Value::Void => None,
             Value::Bool(value) => Some(self.fb.make_imm_value(Immediate::I1(value))),
             Value::BigNum(value) => {
                 let bytes = value.to_be_bytes::<32>();

--- a/plankc/frontend/mir-lower-sona/src/module.rs
+++ b/plankc/frontend/mir-lower-sona/src/module.rs
@@ -109,7 +109,7 @@ fn declare_runtime_shape(
     }
     let shape = match mir.types.lookup(ty) {
         PlankType::Primitive(primitive) => match primitive {
-            PrimitiveType::Void | PrimitiveType::Never => None,
+            PrimitiveType::Never => None,
             PrimitiveType::Bool => Some(SonaType::I1),
             PrimitiveType::U256 | PrimitiveType::MemoryPointer => Some(SonaType::I256),
             PrimitiveType::Function | PrimitiveType::Type | PrimitiveType::CBytes => {

--- a/plankc/frontend/mir-lower-sona/src/tests.rs
+++ b/plankc/frontend/mir-lower-sona/src/tests.rs
@@ -240,14 +240,14 @@ fn lowers_aggregate_access_to_exact_ir() {
         r#"
         target = "evm-ethereum-osaka"
 
-        type @struct_0 = {i256, unit, i256};
+        type @struct_8 = {i256, unit, i256};
 
         func public %init() {
             block0:
                 v1.i256 = evm_calldata_load 0.i256;
                 v3.i256 = evm_calldata_load 32.i256;
-                v5.@struct_0 = insert_value undef.@struct_0 0.i256 v1;
-                v7.@struct_0 = insert_value v5 2.i256 v3;
+                v5.@struct_8 = insert_value undef.@struct_8 0.i256 v1;
+                v7.@struct_8 = insert_value v5 2.i256 v3;
                 v8.*i8 = evm_malloc 32.i256;
                 v9.i256 = ptr_to_int v8 i256;
                 v10.i256 = extract_value v7 2.i256;

--- a/plankc/frontend/mir-lower/src/lib.rs
+++ b/plankc/frontend/mir-lower/src/lib.rs
@@ -72,7 +72,7 @@ impl LowerCtx<'_> {
     fn size_in_locals(&self, ty: TypeId) -> u32 {
         match self.mir.types.lookup(ty) {
             Type::Primitive(prim) => match prim {
-                PrimitiveType::Void | PrimitiveType::Never => 0,
+                PrimitiveType::Never => 0,
                 PrimitiveType::Bool | PrimitiveType::U256 | PrimitiveType::MemoryPointer => 1,
                 PrimitiveType::Function => unreachable!("function unsizeable in SIR"),
                 PrimitiveType::Type | PrimitiveType::CBytes => {
@@ -168,7 +168,6 @@ fn lower_basic_block(
         match instr {
             Instruction::Set { target, expr } => match expr {
                 Expr::Const(vid) => match values.lookup(vid) {
-                    Value::Void => {}
                     Value::Bool(b) => {
                         let value = if b { 1u32 } else { 0u32 };
                         let sets =
@@ -413,7 +412,6 @@ fn materialize_constant_compound_literal(
 ) {
     for &field in fields {
         match values.lookup(field) {
-            Value::Void => {}
             Value::Bool(b) => {
                 let value = match b {
                     true => 1,

--- a/plankc/frontend/mir/src/display.rs
+++ b/plankc/frontend/mir/src/display.rs
@@ -48,7 +48,7 @@ impl<'a> DisplayMir<'a> {
                     write!(f, "0x{x:x}")
                 }
             }
-            Value::Void => write!(f, "void_unit"),
+            Value::Compound { ty, .. } if ty == TypeId::VOID => write!(f, "()"),
             Value::Compound { ty, fields } => {
                 self.fmt_type(f, ty)?;
                 write!(f, " {{")?;

--- a/plankc/frontend/values/src/primitive_types.rs
+++ b/plankc/frontend/values/src/primitive_types.rs
@@ -13,7 +13,6 @@ bitflags::bitflags! {
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(test, derive(enum_iterator::Sequence))]
 pub enum PrimitiveType {
-    Void,
     U256,
     Bool,
     MemoryPointer,
@@ -27,7 +26,6 @@ impl PrimitiveType {
     pub const fn name(self) -> &'static str {
         use plank_session::builtins::builtin_names;
         match self {
-            PrimitiveType::Void => builtin_names::VOID,
             PrimitiveType::U256 => builtin_names::U256,
             PrimitiveType::Bool => builtin_names::BOOL,
             PrimitiveType::MemoryPointer => builtin_names::MEMORY_POINTER,
@@ -40,7 +38,7 @@ impl PrimitiveType {
 
     pub const fn flags(self) -> TypeFlags {
         match self {
-            PrimitiveType::Void | PrimitiveType::U256 | PrimitiveType::Bool => TypeFlags::NONE,
+            PrimitiveType::U256 | PrimitiveType::Bool => TypeFlags::NONE,
             PrimitiveType::MemoryPointer => TypeFlags::RUNTIME_ONLY,
             PrimitiveType::Type => TypeFlags::COMPTIME_ONLY,
             PrimitiveType::Function => TypeFlags::from_bits_retain(

--- a/plankc/frontend/values/src/type_interner.rs
+++ b/plankc/frontend/values/src/type_interner.rs
@@ -194,7 +194,9 @@ pub struct StructRef(CompoundRef);
 pub struct TupleRef(CompoundRef);
 
 impl TypeId {
-    pub const VOID: TypeId = TypeId::from_primitive(PrimitiveType::Void);
+    /// `void` is an alias for the empty tuple `tuple {}`. The empty tuple is pre-interned as the
+    /// first arena allocation in [`TypeInterner::new`], so it always lives at offset 0.
+    pub const VOID: TypeId = TypeId::from_tuple(TupleRef(CompoundRef::new_tuple(0)));
     pub const U256: TypeId = TypeId::from_primitive(PrimitiveType::U256);
     pub const BOOL: TypeId = TypeId::from_primitive(PrimitiveType::Bool);
     pub const MEMORY_POINTER: TypeId = TypeId::from_primitive(PrimitiveType::MemoryPointer);
@@ -254,7 +256,6 @@ impl TypeId {
 
     pub const fn as_primitive(self) -> Result<PrimitiveType, CompoundRef> {
         match self {
-            TypeId::VOID => Ok(PrimitiveType::Void),
             TypeId::U256 => Ok(PrimitiveType::U256),
             TypeId::BOOL => Ok(PrimitiveType::Bool),
             TypeId::MEMORY_POINTER => Ok(PrimitiveType::MemoryPointer),
@@ -290,13 +291,20 @@ const _TYPE_ID_TAGS_OK: () = const {
 
 impl TypeInterner {
     pub fn new() -> Self {
-        Self {
+        let interner = Self {
             struct_dedup: UnsafeCell::new(HashTable::new()),
             tuple_dedup: UnsafeCell::new(HashTable::new()),
             arena: ChunkedArena::new(),
             hasher: DefaultHashBuilder::default(),
             type_name_args: UnsafeCell::new(ListOfLists::new()),
-        }
+        };
+        let (empty_tuple, _) = interner.intern_tuple(TupleKey { fields: &[] });
+        assert_eq!(
+            TypeId::from_tuple(empty_tuple),
+            TypeId::VOID,
+            "empty tuple must be interned first so `void` lands at arena offset 0"
+        );
+        interner
     }
 
     pub fn is_comptime_only(&self, ty: TypeId) -> bool {
@@ -753,13 +761,13 @@ mod tests {
     }
 
     #[test]
-    fn empty_tuple_is_not_void() {
+    fn empty_tuple_is_void() {
         let interner = TypeInterner::new();
         let (tuple, status) = interner.intern_tuple(TupleKey { fields: &[] });
         assert_eq!(status, Ok(()));
         let tuple_ty = TypeId::from_tuple(tuple);
 
-        assert_ne!(tuple_ty, TypeId::VOID);
+        assert_eq!(tuple_ty, TypeId::VOID);
         let Type::Compound(Compound::Tuple(tuple)) = interner.lookup(tuple_ty) else {
             panic!("expected tuple type")
         };

--- a/plankc/frontend/values/src/value_interner.rs
+++ b/plankc/frontend/values/src/value_interner.rs
@@ -15,7 +15,6 @@ newtype_index! {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StoredValue {
-    Void,
     Bool(bool),
     BigNum(BigNumId),
     Type(TypeId),
@@ -26,7 +25,6 @@ enum StoredValue {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Value<'a> {
-    Void,
     Bool(bool),
     BigNum(U256),
     Type(TypeId),
@@ -38,7 +36,6 @@ pub enum Value<'a> {
 impl Value<'_> {
     pub fn get_type(&self) -> TypeId {
         match self {
-            Value::Void => TypeId::VOID,
             Value::Bool(_) => TypeId::BOOL,
             Value::BigNum(_) => TypeId::U256,
             Value::Type(_) => TypeId::TYPE,
@@ -73,7 +70,6 @@ fn stored_to_value<'a>(
     big_nums: &'a BigNumInterner,
 ) -> Value<'a> {
     match stored {
-        StoredValue::Void => Value::Void,
         StoredValue::Bool(b) => Value::Bool(b),
         StoredValue::BigNum(bid) => Value::BigNum(big_nums.lookup(bid)),
         StoredValue::Type(t) => Value::Type(t),
@@ -96,7 +92,10 @@ impl ValueInterner {
             big_nums: BigNumInterner::new(),
             closure_names: HashMap::new(),
         };
-        assert_eq!(new_interner.intern(Value::Void), ValueId::VOID);
+        assert_eq!(
+            new_interner.intern(Value::Compound { ty: TypeId::VOID, fields: &[] }),
+            ValueId::VOID
+        );
         assert_eq!(new_interner.intern(Value::Bool(false)), ValueId::FALSE);
         assert_eq!(new_interner.intern(Value::Bool(true)), ValueId::TRUE);
         assert_eq!(new_interner.intern_num(U256::ZERO), ValueId::ZERO_NUM);
@@ -159,7 +158,6 @@ impl ValueInterner {
             Entry::Occupied(occupied) => *occupied.get(),
             Entry::Vacant(vacant) => {
                 let stored = match value {
-                    Value::Void => StoredValue::Void,
                     Value::Bool(b) => StoredValue::Bool(b),
                     Value::BigNum(n) => StoredValue::BigNum(self.big_nums.intern(n)),
                     Value::Type(t) => StoredValue::Type(t),
@@ -204,7 +202,6 @@ pub struct FmtValue<'a> {
 impl FmtValue<'_> {
     fn fmt_value(&self, f: &mut impl fmt::Write, value: ValueId) -> fmt::Result {
         match self.values.lookup(value) {
-            Value::Void => f.write_str("{}"),
             Value::Bool(value) => write!(f, "{value}"),
             Value::BigNum(value) => write!(f, "{value}"),
             Value::Bytes(value) => {
@@ -229,6 +226,7 @@ impl FmtValue<'_> {
                 }
                 f.write_str(">")
             }
+            Value::Compound { ty, .. } if ty == TypeId::VOID => f.write_str("()"),
             Value::Compound { ty, fields } => match self.types.lookup(ty) {
                 Type::Compound(Compound::Struct(r#struct)) => {
                     write!(f, "{} {{", self.types.format(self.session, self.values, ty))?;
@@ -277,8 +275,8 @@ mod tests {
     #[test]
     fn intern_primitives_dedup() {
         let mut interner = ValueInterner::new();
-        let v1 = interner.intern(Value::Void);
-        let v2 = interner.intern(Value::Void);
+        let v1 = interner.intern(Value::Compound { ty: TypeId::VOID, fields: &[] });
+        let v2 = interner.intern(Value::Compound { ty: TypeId::VOID, fields: &[] });
         assert_eq!(v1, v2);
 
         let b1 = interner.intern(Value::Bool(true));
@@ -291,7 +289,7 @@ mod tests {
     #[test]
     fn intern_compound_dedup() {
         let mut interner = ValueInterner::new();
-        let v1 = interner.intern(Value::Void);
+        let v1 = interner.intern(Value::Compound { ty: TypeId::VOID, fields: &[] });
         let ty = interner.intern(Value::Type(TypeId::new(1)));
 
         let s1 = interner.intern(Value::Compound { ty: TypeId::new(1), fields: &[v1, ty] });


### PR DESCRIPTION
Closes #219 

### Summary

On the surface, this looked like a small change: drop the `void` primitive and treat it as the empty tuple. In practice, it surfaced a few decisions worth calling out for review.

### Decisions this opened up

1. **`void` is now literally the empty tuple, not a distinct type.** `TypeId::VOID`, `()`, and `tuple {}` all refer to the same interned type. This unifies them by construction, but it means anything that previously special-cased `void` as a primitive now flows through the compound/tuple path instead.

2. **The empty tuple is pre-interned at arena offset 0.** `TypeInterner::new()` interns `tuple {}` first and asserts it lands at the offset baked into the `TypeId::VOID` constant. This is a runtime invariant (arena layout can't be type-enforced), so it's guarded with an `assert_eq!`.

3. **Cross-interner ordering dependency.** `ValueId::VOID` is now the empty-tuple *value* (`Compound { ty: VOID, fields: [] }`), which depends on the type interner having pre-interned the empty tuple. Each `new()` self-checks, but the ordering between the two interners is now load-bearing.

4. **Aggregate type ids shift.** Because the empty tuple now occupies offset 0, every subsequently-interned compound's id moves up one slot (e.g. `@struct_0` → `@struct_8` in the Sonatina IR). This is cosmetic but visible in exact-IR test expectations.

### AI disclosure

Per [CONTRIBUTING.md](../../CONTRIBUTING.md), disclosing AI use: I used AI **only to understand the codebase**. Even so, this genuinely needs a careful human review.
