### PR TITLE
Implement `comptime let mut`

### DIFF
--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -320,6 +320,27 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
+    pub fn emit_comptime_var_assign_in_runtime_context(&mut self, loc: SrcLoc, use_loc: SrcLoc, forced_by_expr: Option<SrcLoc>) {
+        let mut diagnostic = Diagnostic::error("assignment to mutable comptime variable in implicit runtime context")
+            .cross_source_annotations(
+                loc,
+                "assignment in implicit runtime context",
+                use_loc,
+                "comptime mutable variable defined here",
+            );
+
+        if let Some(forced_by_expr) = forced_by_expr {
+            diagnostic = diagnostic.claim(
+                Claim::new(Level::Note, "runtime evaluation forced here").element(
+                    Annotations::new(forced_by_expr.source)
+                        .no_label(forced_by_expr.span, AnnotationKind::Primary),
+                ),
+            );
+        }
+
+        diagnostic.emit(self);
+    }
+
     pub fn emit_eval_branch_quota_too_large(&mut self, loc: SrcLoc) {
         Diagnostic::error("eval branch quota is too large")
             .primary(loc.source, loc.span, "quota must fit in u32")

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -320,14 +320,21 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn emit_comptime_var_assign_in_runtime_context(&mut self, loc: SrcLoc, use_loc: SrcLoc, forced_by_expr: Option<SrcLoc>) {
-        let mut diagnostic = Diagnostic::error("assignment to mutable comptime variable in implicit runtime context")
-            .cross_source_annotations(
-                loc,
-                "assignment in implicit runtime context",
-                use_loc,
-                "comptime mutable variable defined here",
-            );
+    pub fn emit_comptime_var_assign_in_runtime_context(
+        &mut self,
+        loc: SrcLoc,
+        use_loc: SrcLoc,
+        forced_by_expr: Option<SrcLoc>,
+    ) {
+        let mut diagnostic = Diagnostic::error(
+            "assignment to mutable comptime variable in implicit runtime context",
+        )
+        .cross_source_annotations(
+            loc,
+            "assignment in implicit runtime context",
+            use_loc,
+            "comptime mutable variable defined here",
+        );
 
         if let Some(forced_by_expr) = forced_by_expr {
             diagnostic = diagnostic.claim(

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -320,21 +320,15 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn emit_comptime_var_assign_in_runtime_context(
-        &mut self,
-        loc: SrcLoc,
-        use_loc: SrcLoc,
-    ) {
-        Diagnostic::error(
-            "assignment to mutable comptime variable in implicit runtime context",
-        )
-        .cross_source_annotations(
-            loc,
-            "assignment in implicit runtime context",
-            use_loc,
-            "comptime mutable variable defined here",
-        )
-        .emit(self);
+    pub fn emit_comptime_var_assign_in_runtime_context(&mut self, loc: SrcLoc, use_loc: SrcLoc) {
+        Diagnostic::error("assignment to mutable comptime variable in implicit runtime context")
+            .cross_source_annotations(
+                loc,
+                "assignment in implicit runtime context",
+                use_loc,
+                "comptime mutable variable defined here",
+            )
+            .emit(self);
     }
 
     pub fn emit_eval_branch_quota_too_large(&mut self, loc: SrcLoc) {

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -324,9 +324,8 @@ impl DiagCtx<'_> {
         &mut self,
         loc: SrcLoc,
         use_loc: SrcLoc,
-        forced_by_expr: Option<SrcLoc>,
     ) {
-        let mut diagnostic = Diagnostic::error(
+        Diagnostic::error(
             "assignment to mutable comptime variable in implicit runtime context",
         )
         .cross_source_annotations(
@@ -334,18 +333,8 @@ impl DiagCtx<'_> {
             "assignment in implicit runtime context",
             use_loc,
             "comptime mutable variable defined here",
-        );
-
-        if let Some(forced_by_expr) = forced_by_expr {
-            diagnostic = diagnostic.claim(
-                Claim::new(Level::Note, "runtime evaluation forced here").element(
-                    Annotations::new(forced_by_expr.source)
-                        .no_label(forced_by_expr.span, AnnotationKind::Primary),
-                ),
-            );
-        }
-
-        diagnostic.emit(self);
+        )
+        .emit(self);
     }
 
     pub fn emit_eval_branch_quota_too_large(&mut self, loc: SrcLoc) {
@@ -1202,6 +1191,15 @@ impl DiagCtx<'_> {
     pub fn emit_failed_to_resolve_std_fn(&mut self, source: SourceId, op_name: &str) {
         Diagnostic::error(format!("failed to resolve core operation handler `{op_name}`"))
             .element(Element::Origin { path: source })
+            .emit(self);
+    }
+
+    pub fn emit_comptime_var_redundant_in_comptime_context(&mut self, loc: SrcLoc) {
+        Diagnostic::error("'comptime let mut' is redundant in comptime context")
+            .element(
+                Annotations::new(loc.source)
+                    .no_label(loc.span, plank_session::AnnotationKind::Primary),
+            )
             .emit(self);
     }
 }

--- a/plankc/frontend/hir-eval/src/evaluator.rs
+++ b/plankc/frontend/hir-eval/src/evaluator.rs
@@ -142,7 +142,7 @@ impl<'a> Evaluator<'a> {
             const_def.loc(),
             EvalContext::Other,
         );
-        match scope.eval_comptime(const_def.body) {
+        match scope.with_comptime(|this| this.eval_block_inline(const_def.body)) {
             Err(Diverge::ComptimeQuotaExhausted) => {
                 self.evaluated_consts[const_id] = State::Done(ConstEvalResult::QuotaExhausted);
                 return Err(Poisoned);

--- a/plankc/frontend/hir-eval/src/functions/mod.rs
+++ b/plankc/frontend/hir-eval/src/functions/mod.rs
@@ -164,7 +164,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         fn_def_id: hir::FnDefId,
     ) -> Result<MaybePoisoned<PreambleResult>, Diverge> {
         let fn_def = self.hir.fns[fn_def_id];
-        match self.eval_comptime(fn_def.type_preamble) {
+        match self.with_comptime(|this| this.eval_block_inline(fn_def.type_preamble)) {
             Ok(()) => {}
             Err(Diverge::ComptimeQuotaExhausted) => {
                 return Err(Diverge::ComptimeQuotaExhausted);
@@ -621,7 +621,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         cache_state.set(EvaluatedFnState::InProgress);
 
         let spent_before_body = self.comptime_quota.spent();
-        let eval_res = match self.eval_comptime(call.func.body) {
+        let eval_res = match self.with_comptime(|this| this.eval_block_inline(call.func.body)) {
             Ok(()) => unreachable!("lowerer should guarantee return in function body"),
             Err(Diverge::ControlFlowPoisoned) if preamble.return_type == Ok(TypeId::NEVER) => {
                 Ok(Err(Diverge::END))

--- a/plankc/frontend/hir-eval/src/functions/mod.rs
+++ b/plankc/frontend/hir-eval/src/functions/mod.rs
@@ -107,6 +107,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                             state: Err(Poisoned),
                             use_span: param.span,
                             origin: DefOrigin::Local(param.span),
+                            comptime_mut: false,
                         },
                     );
                     continue;
@@ -138,7 +139,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             };
             fn_scope.bindings.insert_no_prev(
                 param.value,
-                Local { state, use_span: param.span, origin: DefOrigin::Local(param.span) },
+                Local {
+                    state,
+                    use_span: param.span,
+                    origin: DefOrigin::Local(param.span),
+                    comptime_mut: false,
+                },
             );
         }
 
@@ -760,6 +766,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                             state: Err(Poisoned),
                             use_span: arg_binding.use_span,
                             origin: DefOrigin::Local(arg_binding.use_span),
+                            comptime_mut: false,
                         },
                     );
                     return;

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -60,6 +60,13 @@ pub(crate) enum EvalContext {
     Other,
 }
 
+pub(crate) enum ComptimeVarAssignment {
+    Allowed,
+    Blocked {
+        forced_by: Option<hir::LocalId>
+    }
+}
+
 pub(crate) struct Scope<'a, 'ctx> {
     pub eval: &'a mut Evaluator<'ctx>,
     pub diag_ctx: &'a mut DiagCtx<'ctx>,
@@ -68,6 +75,7 @@ pub(crate) struct Scope<'a, 'ctx> {
     pub ctx: EvalContext,
     pub comptime: bool,
     pub conditional: bool,
+    pub comptime_var_assignment: ComptimeVarAssignment,
     pub comptime_quota: ComptimeQuota,
     pub eval_branch_quota_start_loc: SrcLoc,
     pub max_eval_branch_quota_seen: u32,
@@ -93,6 +101,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             source,
             ctx,
             comptime,
+            comptime_var_assignment: ComptimeVarAssignment::Allowed,
             conditional: false,
             comptime_quota,
             eval_branch_quota_start_loc,
@@ -125,6 +134,13 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         let res = self.eval_block_inline(block);
         self.comptime = parent_comptime;
         res
+    }
+
+    pub fn eval_comptime_expr(&mut self, expr: hir::Expr) -> Result<MaybePoisoned<EvalValue>, Diverge> {
+        let parent_comptime = std::mem::replace(&mut self.comptime, true);
+        let value = self.eval_expr(expr);
+        self.comptime = parent_comptime;
+        value
     }
 
     pub fn emit(&mut self, instr: mir::Instruction) {
@@ -316,6 +332,34 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         Ok(())
     }
 
+    fn eval_comptime_set_mut(
+        &mut self,
+        local: hir::LocalId,
+        r#type: Option<hir::LocalId>,
+        expr: hir::Expr,
+    ) -> Result<(), Diverge> {
+        let value = self.eval_comptime_expr(expr)?;
+        let value = value.and_then(|value| {
+            let Some(type_local) = r#type else {
+                return Ok(value);
+            };
+            let expected_ty = self.expect_type(type_local)?;
+            let type_loc = self.loc(self.bindings[type_local].use_span);
+            self.type_check(value, expected_ty, type_loc, expr.span)?;
+            Ok(value)
+        });
+
+        let new_state = value.and_then(|value| {
+            self.expect_comptime_value(value, expr.span).map(LocalState::Comptime)
+        });
+
+        self.bindings.insert(
+            local,
+            Local { state: new_state, use_span: expr.span, origin: self.expr_origin(expr) },
+        );
+        Ok(())
+    }
+
     fn eval_branch_set(&mut self, local: hir::LocalId, expr: hir::Expr) -> Result<(), Diverge> {
         if !self.conditional {
             return self.eval_set(local, None, expr);
@@ -450,15 +494,57 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         Ok(())
     }
 
+    fn eval_comptime_assign(&mut self, target: hir::LocalId, expr: hir::Expr) -> Result<(), Diverge> {
+        let value = self.eval_comptime_expr(expr)?;
+        let local = self.bindings[target];
+        let new_state = poison::zip(local.state, value).and_then(|(state, value)| {
+            if let ComptimeVarAssignment::Blocked { forced_by } = self.comptime_var_assignment {
+                self.diag_ctx.emit_comptime_var_assign_in_runtime_context(
+                    self.loc(expr.span),
+                    self.loc(local.use_span),
+                    forced_by.map(|l| self.loc(self.bindings[l].use_span)),
+                );
+                return Err(Poisoned)
+            }
+            let expected_ty = self.state_type(state);
+            let type_check =
+                self.type_check(value, expected_ty, self.origin_loc(local.origin), expr.span);
+            let state = match state {
+                LocalState::Comptime(vid) => Ok(vid),
+                LocalState::Runtime(_) => {
+                    self.diag_ctx.emit_runtime_ref_in_comptime(
+                        self.origin_loc(local.origin),
+                        self.loc(expr.span),
+                    );
+                    Err(Poisoned)
+                }
+            };
+            let value = self.expect_comptime_value(value, expr.span);
+            type_check.and(state).and(value).map(LocalState::Comptime)
+        });
+        self.bindings[target].state = new_state;
+        Ok(())
+    }
+
     pub fn eval_instr(&mut self, instr: hir::Instruction) -> Result<(), Diverge> {
         match instr.kind {
-            InstructionKind::Set { local, r#type, expr } => self.eval_set(local, r#type, expr)?,
-            InstructionKind::SetMut { local, r#type, expr } => {
-                self.eval_set_mut(local, r#type, expr)?
+            InstructionKind::Set { local, r#type, expr, .. } => self.eval_set(local, r#type, expr)?,
+            InstructionKind::SetMut { local, r#type, expr, comptime } => {
+                if comptime {
+                    self.eval_comptime_set_mut(local, r#type, expr)?
+                } else {
+                    self.eval_set_mut(local, r#type, expr)?
+                }
             }
             InstructionKind::BranchSet { local, expr } => self.eval_branch_set(local, expr)?,
             InstructionKind::ComptimeBlock { body } => self.eval_comptime(body)?,
-            InstructionKind::Assign { target, expr } => self.eval_assign(target, expr)?,
+            InstructionKind::Assign { target, expr, comptime } => {
+                if comptime {
+                    self.eval_comptime_assign(target, expr)?
+                } else {
+                    self.eval_assign(target, expr)?
+                }
+            }
             InstructionKind::Eval(expr) => {
                 let value = self.eval_expr(expr)?;
                 if self.is_comptime() {
@@ -494,6 +580,15 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         let prev_conditional = std::mem::replace(&mut self.conditional, conditional);
         let result = inner(self);
         self.conditional = prev_conditional;
+
+        result
+    }
+
+    fn with_comptime_assignment<R>(&mut self, comptime_var_assignment: ComptimeVarAssignment, inner: impl FnOnce(&mut Self) -> R) -> R {
+        let prev_comptime_var_assignment = std::mem::replace(&mut self.comptime_var_assignment, comptime_var_assignment);
+        let result = inner(self);
+        self.comptime_var_assignment = prev_comptime_var_assignment;
+
         result
     }
 
@@ -513,9 +608,20 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                     return Err(Diverge::ControlFlowPoisoned);
                 }
                 let (then, then_res) =
-                    self.with_conditional(true, |this| this.eval_block_to_mir(then));
+                    self.with_conditional(true, |this| {
+                        this.with_comptime_assignment(
+                            ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
+                            |this| this.eval_block_to_mir(then)
+                        )
+                    });
                 let (r#else, else_res) =
-                    self.with_conditional(true, |this| this.eval_block_to_mir(r#else));
+                    self.with_conditional(true, |this| {
+                        this.with_comptime_assignment(
+                            ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
+                            |this| this.eval_block_to_mir(r#else)
+                        )
+                    });
+
                 self.emit(mir::Instruction::If {
                     condition: mir_local,
                     then_block: then,
@@ -613,15 +719,18 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 }
             }
         });
-        let condition = mir_condition_local?;
-        let (body, body_res) = self.eval_block_to_mir(body);
+        let mir_condition = mir_condition_local?;
+        let (body, body_res) = self.with_comptime_assignment(
+            ComptimeVarAssignment::Blocked { forced_by: None },
+            |this| this.eval_block_to_mir(body)
+        );
         match body_res {
             Err(err @ (Diverge::ControlFlowPoisoned | Diverge::ComptimeQuotaExhausted)) => {
                 return Err(err);
             }
             Err(Diverge::BlockEnd(_)) | Ok(()) => {}
         }
-        self.emit(mir::Instruction::While { condition_block, condition, body });
+        self.emit(mir::Instruction::While { condition_block, condition: mir_condition, body });
 
         Ok(())
     }

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -477,7 +477,8 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             InstructionKind::Set { local, r#type, expr } => self.eval_set(local, r#type, expr)?,
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
                 if comptime && self.comptime {
-                    self.diag_ctx.emit_comptime_var_redundant_in_comptime_context(self.loc(expr.span));
+                    self.diag_ctx
+                        .emit_comptime_var_redundant_in_comptime_context(self.loc(expr.span));
                     self.eval_set_mut(local, r#type, expr)?
                 } else if comptime {
                     self.with_comptime(|this| this.eval_set_mut(local, r#type, expr))?
@@ -488,7 +489,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             InstructionKind::BranchSet { local, expr } => self.eval_branch_set(local, expr)?,
             InstructionKind::ComptimeBlock { body } => {
                 self.with_comptime(|this| this.eval_block_inline(body))?
-            },
+            }
             InstructionKind::Assign { target, expr, comptime } => {
                 if comptime {
                     self.eval_comptime_assign(target, expr)?
@@ -548,13 +549,8 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         result
     }
 
-    fn with_runtime_branch<R>(
-        &mut self,
-        inner: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        self.with_conditional(true, |this| {
-            this.with_comptime_var_assignability(false, inner)
-        })
+    fn with_runtime_branch<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
+        self.with_conditional(true, |this| this.with_comptime_var_assignability(false, inner))
     }
 
     fn eval_if(
@@ -573,13 +569,11 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                     return Err(Diverge::ControlFlowPoisoned);
                 }
 
-                let (then, then_res) = self.with_runtime_branch(
-                    |this| this.eval_block_to_mir(then)
-                );
+                let (then, then_res) =
+                    self.with_runtime_branch(|this| this.eval_block_to_mir(then));
 
-                let (r#else, else_res) = self.with_runtime_branch(
-                    |this| this.eval_block_to_mir(r#else)
-                );
+                let (r#else, else_res) =
+                    self.with_runtime_branch(|this| this.eval_block_to_mir(r#else));
 
                 self.emit(mir::Instruction::If {
                     condition: mir_local,
@@ -679,8 +673,8 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             }
         });
         let mir_condition = mir_condition_local?;
-        let (body, body_res) = self
-            .with_comptime_var_assignability(false, |this| this.eval_block_to_mir(body));
+        let (body, body_res) =
+            self.with_comptime_var_assignability(false, |this| this.eval_block_to_mir(body));
         match body_res {
             Err(err @ (Diverge::ControlFlowPoisoned | Diverge::ComptimeQuotaExhausted)) => {
                 return Err(err);

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -60,11 +60,6 @@ pub(crate) enum EvalContext {
     Other,
 }
 
-pub(crate) enum ComptimeVarAssignment {
-    Allowed,
-    Blocked { forced_by: Option<hir::LocalId> },
-}
-
 pub(crate) struct Scope<'a, 'ctx> {
     pub eval: &'a mut Evaluator<'ctx>,
     pub diag_ctx: &'a mut DiagCtx<'ctx>,
@@ -73,7 +68,7 @@ pub(crate) struct Scope<'a, 'ctx> {
     pub ctx: EvalContext,
     pub comptime: bool,
     pub conditional: bool,
-    pub comptime_var_assignment: ComptimeVarAssignment,
+    pub comptime_var_assignability: bool,
     pub comptime_quota: ComptimeQuota,
     pub eval_branch_quota_start_loc: SrcLoc,
     pub max_eval_branch_quota_seen: u32,
@@ -99,7 +94,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             source,
             ctx,
             comptime,
-            comptime_var_assignment: ComptimeVarAssignment::Allowed,
+            comptime_var_assignability: true,
             conditional: false,
             comptime_quota,
             eval_branch_quota_start_loc,
@@ -462,25 +457,29 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         target: hir::LocalId,
         expr: hir::Expr,
     ) -> Result<(), Diverge> {
-        if let ComptimeVarAssignment::Blocked { forced_by } = self.comptime_var_assignment {
-            let _ = self.with_comptime(|this| this.eval_expr(expr))?;
-            let local = self.bindings[target];
-            self.diag_ctx.emit_comptime_var_assign_in_runtime_context(
-                self.loc(expr.span),
-                self.loc(local.use_span),
-                forced_by.map(|l| self.loc(self.bindings[l].use_span)),
-            );
-            self.bindings[target].state = Err(Poisoned);
-            return Ok(());
-        }
-        self.with_comptime(|this| this.eval_assign(target, expr))
+        self.with_comptime(|this| {
+            if !this.comptime_var_assignability {
+                let _ = this.eval_expr(expr);
+                let local = this.bindings[target];
+                this.diag_ctx.emit_comptime_var_assign_in_runtime_context(
+                    this.loc(expr.span),
+                    this.loc(local.use_span),
+                );
+                this.bindings[target].state = Err(Poisoned);
+                return Ok(());
+            }
+            this.eval_assign(target, expr)
+        })
     }
 
     pub fn eval_instr(&mut self, instr: hir::Instruction) -> Result<(), Diverge> {
         match instr.kind {
             InstructionKind::Set { local, r#type, expr } => self.eval_set(local, r#type, expr)?,
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
-                if comptime {
+                if comptime && self.comptime {
+                    self.diag_ctx.emit_comptime_var_redundant_in_comptime_context(self.loc(expr.span));
+                    self.eval_set_mut(local, r#type, expr)?
+                } else if comptime {
                     self.with_comptime(|this| this.eval_set_mut(local, r#type, expr))?
                 } else {
                     self.eval_set_mut(local, r#type, expr)?
@@ -536,29 +535,25 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         result
     }
 
-    fn with_comptime_assignment<R>(
+    fn with_comptime_var_assignability<R>(
         &mut self,
-        comptime_var_assignment: ComptimeVarAssignment,
+        comptime_var_assignability: bool,
         inner: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        let prev_comptime_var_assignment =
-            std::mem::replace(&mut self.comptime_var_assignment, comptime_var_assignment);
+        let prev_comptime_var_assignability =
+            std::mem::replace(&mut self.comptime_var_assignability, comptime_var_assignability);
         let result = inner(self);
-        self.comptime_var_assignment = prev_comptime_var_assignment;
+        self.comptime_var_assignability = prev_comptime_var_assignability;
 
         result
     }
 
     fn with_runtime_branch<R>(
         &mut self,
-        forced_by: Option<hir::LocalId>,
         inner: impl FnOnce(&mut Self) -> R,
     ) -> R {
         self.with_conditional(true, |this| {
-            this.with_comptime_assignment(
-                ComptimeVarAssignment::Blocked { forced_by },
-                inner,
-            )
+            this.with_comptime_var_assignability(false, inner)
         })
     }
 
@@ -579,12 +574,10 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 }
 
                 let (then, then_res) = self.with_runtime_branch(
-                    Some(condition),
                     |this| this.eval_block_to_mir(then)
                 );
 
                 let (r#else, else_res) = self.with_runtime_branch(
-                    Some(condition),
                     |this| this.eval_block_to_mir(r#else)
                 );
 
@@ -687,9 +680,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         });
         let mir_condition = mir_condition_local?;
         let (body, body_res) = self
-            .with_comptime_assignment(ComptimeVarAssignment::Blocked { forced_by: None }, |this| {
-                this.eval_block_to_mir(body)
-            });
+            .with_comptime_var_assignability(false, |this| this.eval_block_to_mir(body));
         match body_res {
             Err(err @ (Diverge::ControlFlowPoisoned | Diverge::ComptimeQuotaExhausted)) => {
                 return Err(err);

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -549,6 +549,19 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         result
     }
 
+    fn with_runtime_branch<R>(
+        &mut self,
+        forced_by: Option<hir::LocalId>,
+        inner: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.with_conditional(true, |this| {
+            this.with_comptime_assignment(
+                ComptimeVarAssignment::Blocked { forced_by },
+                inner,
+            )
+        })
+    }
+
     fn eval_if(
         &mut self,
         condition: hir::LocalId,
@@ -564,18 +577,16 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                     self.diag_ctx.emit_runtime_eval_in_comptime(self.loc(binding.use_span));
                     return Err(Diverge::ControlFlowPoisoned);
                 }
-                let (then, then_res) = self.with_conditional(true, |this| {
-                    this.with_comptime_assignment(
-                        ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
-                        |this| this.eval_block_to_mir(then),
-                    )
-                });
-                let (r#else, else_res) = self.with_conditional(true, |this| {
-                    this.with_comptime_assignment(
-                        ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
-                        |this| this.eval_block_to_mir(r#else),
-                    )
-                });
+
+                let (then, then_res) = self.with_runtime_branch(
+                    Some(condition),
+                    |this| this.eval_block_to_mir(then)
+                );
+
+                let (r#else, else_res) = self.with_runtime_branch(
+                    Some(condition),
+                    |this| this.eval_block_to_mir(r#else)
+                );
 
                 self.emit(mir::Instruction::If {
                     condition: mir_local,

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -127,7 +127,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         mir_block
     }
 
-    fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
+    pub fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
         let parent_comptime = std::mem::replace(&mut self.comptime, true);
         let result = inner(self);
         self.comptime = parent_comptime;

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -127,13 +127,6 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         mir_block
     }
 
-    pub fn eval_comptime(&mut self, block: hir::BlockId) -> Result<(), Diverge> {
-        let parent_comptime = std::mem::replace(&mut self.comptime, true);
-        let res = self.eval_block_inline(block);
-        self.comptime = parent_comptime;
-        res
-    }
-
     fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
         let parent_comptime = std::mem::replace(&mut self.comptime, true);
         let result = inner(self);
@@ -494,7 +487,9 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 }
             }
             InstructionKind::BranchSet { local, expr } => self.eval_branch_set(local, expr)?,
-            InstructionKind::ComptimeBlock { body } => self.eval_comptime(body)?,
+            InstructionKind::ComptimeBlock { body } => {
+                self.with_comptime(|this| this.eval_block_inline(body))?
+            },
             InstructionKind::Assign { target, expr, comptime } => {
                 if comptime {
                     self.eval_comptime_assign(target, expr)?

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -134,14 +134,11 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         res
     }
 
-    pub fn eval_comptime_expr(
-        &mut self,
-        expr: hir::Expr,
-    ) -> Result<MaybePoisoned<EvalValue>, Diverge> {
+    fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
         let parent_comptime = std::mem::replace(&mut self.comptime, true);
-        let value = self.eval_expr(expr);
+        let result = inner(self);
         self.comptime = parent_comptime;
-        value
+        result
     }
 
     pub fn emit(&mut self, instr: mir::Instruction) {
@@ -333,34 +330,6 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         Ok(())
     }
 
-    fn eval_comptime_set_mut(
-        &mut self,
-        local: hir::LocalId,
-        r#type: Option<hir::LocalId>,
-        expr: hir::Expr,
-    ) -> Result<(), Diverge> {
-        let value = self.eval_comptime_expr(expr)?;
-        let value = value.and_then(|value| {
-            let Some(type_local) = r#type else {
-                return Ok(value);
-            };
-            let expected_ty = self.expect_type(type_local)?;
-            let type_loc = self.loc(self.bindings[type_local].use_span);
-            self.type_check(value, expected_ty, type_loc, expr.span)?;
-            Ok(value)
-        });
-
-        let new_state = value.and_then(|value| {
-            self.expect_comptime_value(value, expr.span).map(LocalState::Comptime)
-        });
-
-        self.bindings.insert(
-            local,
-            Local { state: new_state, use_span: expr.span, origin: self.expr_origin(expr) },
-        );
-        Ok(())
-    }
-
     fn eval_branch_set(&mut self, local: hir::LocalId, expr: hir::Expr) -> Result<(), Diverge> {
         if !self.conditional {
             return self.eval_set(local, None, expr);
@@ -500,35 +469,18 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         target: hir::LocalId,
         expr: hir::Expr,
     ) -> Result<(), Diverge> {
-        let value = self.eval_comptime_expr(expr)?;
-        let local = self.bindings[target];
-        let new_state = poison::zip(local.state, value).and_then(|(state, value)| {
-            if let ComptimeVarAssignment::Blocked { forced_by } = self.comptime_var_assignment {
-                self.diag_ctx.emit_comptime_var_assign_in_runtime_context(
-                    self.loc(expr.span),
-                    self.loc(local.use_span),
-                    forced_by.map(|l| self.loc(self.bindings[l].use_span)),
-                );
-                return Err(Poisoned);
-            }
-            let expected_ty = self.state_type(state);
-            let type_check =
-                self.type_check(value, expected_ty, self.origin_loc(local.origin), expr.span);
-            let state = match state {
-                LocalState::Comptime(vid) => Ok(vid),
-                LocalState::Runtime(_) => {
-                    self.diag_ctx.emit_runtime_ref_in_comptime(
-                        self.origin_loc(local.origin),
-                        self.loc(expr.span),
-                    );
-                    Err(Poisoned)
-                }
-            };
-            let value = self.expect_comptime_value(value, expr.span);
-            type_check.and(state).and(value).map(LocalState::Comptime)
-        });
-        self.bindings[target].state = new_state;
-        Ok(())
+        if let ComptimeVarAssignment::Blocked { forced_by } = self.comptime_var_assignment {
+            let _ = self.with_comptime(|this| this.eval_expr(expr))?;
+            let local = self.bindings[target];
+            self.diag_ctx.emit_comptime_var_assign_in_runtime_context(
+                self.loc(expr.span),
+                self.loc(local.use_span),
+                forced_by.map(|l| self.loc(self.bindings[l].use_span)),
+            );
+            self.bindings[target].state = Err(Poisoned);
+            return Ok(());
+        }
+        self.with_comptime(|this| this.eval_assign(target, expr))
     }
 
     pub fn eval_instr(&mut self, instr: hir::Instruction) -> Result<(), Diverge> {
@@ -536,7 +488,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             InstructionKind::Set { local, r#type, expr } => self.eval_set(local, r#type, expr)?,
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
                 if comptime {
-                    self.eval_comptime_set_mut(local, r#type, expr)?
+                    self.with_comptime(|this| this.eval_set_mut(local, r#type, expr))?
                 } else {
                     self.eval_set_mut(local, r#type, expr)?
                 }

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -15,11 +15,12 @@ pub(crate) struct Local {
     pub state: MaybePoisoned<LocalState>,
     pub use_span: SourceSpan,
     pub origin: DefOrigin,
+    pub comptime_mut: bool,
 }
 
 impl Local {
     pub fn comptime(value: ValueId, use_span: SourceSpan, origin: DefOrigin) -> Self {
-        Self { state: Ok(LocalState::Comptime(value)), use_span, origin }
+        Self { state: Ok(LocalState::Comptime(value)), use_span, origin, comptime_mut: false }
     }
 
     pub fn poisoned(self) -> MaybePoisoned<(LocalState, SourceSpan, DefOrigin)> {
@@ -277,8 +278,15 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 }
             }
         });
-        self.bindings
-            .insert(local, Local { state, use_span: expr.span, origin: self.expr_origin(expr) });
+        self.bindings.insert(
+            local,
+            Local {
+                state,
+                use_span: expr.span,
+                origin: self.expr_origin(expr),
+                comptime_mut: false,
+            },
+        );
         Ok(())
     }
 
@@ -287,6 +295,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         local: hir::LocalId,
         r#type: Option<hir::LocalId>,
         expr: hir::Expr,
+        comptime_mut: bool,
     ) -> Result<(), Diverge> {
         let value = self.eval_expr(expr)?;
         let value = value.and_then(|value| {
@@ -313,7 +322,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
 
         self.bindings.insert(
             local,
-            Local { state: new_state, use_span: expr.span, origin: self.expr_origin(expr) },
+            Local {
+                state: new_state,
+                use_span: expr.span,
+                origin: self.expr_origin(expr),
+                comptime_mut,
+            },
         );
         Ok(())
     }
@@ -329,7 +343,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 .map(LocalState::Comptime);
             let _ = self.bindings.insert(
                 local,
-                Local { state, use_span: expr.span, origin: self.expr_origin(expr) },
+                Local {
+                    state,
+                    use_span: expr.span,
+                    origin: self.expr_origin(expr),
+                    comptime_mut: false,
+                },
             );
             return Ok(());
         }
@@ -344,7 +363,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 });
                 self.bindings.insert(
                     local,
-                    Local { state, use_span: expr.span, origin: self.expr_origin(expr) },
+                    Local {
+                        state,
+                        use_span: expr.span,
+                        origin: self.expr_origin(expr),
+                        comptime_mut: false,
+                    },
                 );
             }
             Some(binding) => {
@@ -371,8 +395,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                         Ok(LocalState::Runtime(target))
                     },
                 );
-                self.bindings[local] =
-                    Local { state: new_state, use_span: expr.span, origin: self.expr_origin(expr) };
+                self.bindings[local] = Local {
+                    state: new_state,
+                    use_span: expr.span,
+                    origin: self.expr_origin(expr),
+                    comptime_mut: binding.comptime_mut,
+                };
             }
         }
 
@@ -479,19 +507,19 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                 if comptime && self.comptime {
                     self.diag_ctx
                         .emit_comptime_var_redundant_in_comptime_context(self.loc(expr.span));
-                    self.eval_set_mut(local, r#type, expr)?
+                    self.eval_set_mut(local, r#type, expr, comptime)?
                 } else if comptime {
-                    self.with_comptime(|this| this.eval_set_mut(local, r#type, expr))?
+                    self.with_comptime(|this| this.eval_set_mut(local, r#type, expr, comptime))?
                 } else {
-                    self.eval_set_mut(local, r#type, expr)?
+                    self.eval_set_mut(local, r#type, expr, comptime)?
                 }
             }
             InstructionKind::BranchSet { local, expr } => self.eval_branch_set(local, expr)?,
             InstructionKind::ComptimeBlock { body } => {
                 self.with_comptime(|this| this.eval_block_inline(body))?
             }
-            InstructionKind::Assign { target, expr, comptime } => {
-                if comptime {
+            InstructionKind::Assign { target, expr } => {
+                if self.bindings[target].comptime_mut {
                     self.eval_comptime_assign(target, expr)?
                 } else {
                     self.eval_assign(target, expr)?

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -62,9 +62,7 @@ pub(crate) enum EvalContext {
 
 pub(crate) enum ComptimeVarAssignment {
     Allowed,
-    Blocked {
-        forced_by: Option<hir::LocalId>
-    }
+    Blocked { forced_by: Option<hir::LocalId> },
 }
 
 pub(crate) struct Scope<'a, 'ctx> {
@@ -136,7 +134,10 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         res
     }
 
-    pub fn eval_comptime_expr(&mut self, expr: hir::Expr) -> Result<MaybePoisoned<EvalValue>, Diverge> {
+    pub fn eval_comptime_expr(
+        &mut self,
+        expr: hir::Expr,
+    ) -> Result<MaybePoisoned<EvalValue>, Diverge> {
         let parent_comptime = std::mem::replace(&mut self.comptime, true);
         let value = self.eval_expr(expr);
         self.comptime = parent_comptime;
@@ -494,7 +495,11 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         Ok(())
     }
 
-    fn eval_comptime_assign(&mut self, target: hir::LocalId, expr: hir::Expr) -> Result<(), Diverge> {
+    fn eval_comptime_assign(
+        &mut self,
+        target: hir::LocalId,
+        expr: hir::Expr,
+    ) -> Result<(), Diverge> {
         let value = self.eval_comptime_expr(expr)?;
         let local = self.bindings[target];
         let new_state = poison::zip(local.state, value).and_then(|(state, value)| {
@@ -504,7 +509,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                     self.loc(local.use_span),
                     forced_by.map(|l| self.loc(self.bindings[l].use_span)),
                 );
-                return Err(Poisoned)
+                return Err(Poisoned);
             }
             let expected_ty = self.state_type(state);
             let type_check =
@@ -528,7 +533,9 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
 
     pub fn eval_instr(&mut self, instr: hir::Instruction) -> Result<(), Diverge> {
         match instr.kind {
-            InstructionKind::Set { local, r#type, expr, .. } => self.eval_set(local, r#type, expr)?,
+            InstructionKind::Set { local, r#type, expr, .. } => {
+                self.eval_set(local, r#type, expr)?
+            }
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
                 if comptime {
                     self.eval_comptime_set_mut(local, r#type, expr)?
@@ -584,8 +591,13 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         result
     }
 
-    fn with_comptime_assignment<R>(&mut self, comptime_var_assignment: ComptimeVarAssignment, inner: impl FnOnce(&mut Self) -> R) -> R {
-        let prev_comptime_var_assignment = std::mem::replace(&mut self.comptime_var_assignment, comptime_var_assignment);
+    fn with_comptime_assignment<R>(
+        &mut self,
+        comptime_var_assignment: ComptimeVarAssignment,
+        inner: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let prev_comptime_var_assignment =
+            std::mem::replace(&mut self.comptime_var_assignment, comptime_var_assignment);
         let result = inner(self);
         self.comptime_var_assignment = prev_comptime_var_assignment;
 
@@ -607,20 +619,18 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
                     self.diag_ctx.emit_runtime_eval_in_comptime(self.loc(binding.use_span));
                     return Err(Diverge::ControlFlowPoisoned);
                 }
-                let (then, then_res) =
-                    self.with_conditional(true, |this| {
-                        this.with_comptime_assignment(
-                            ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
-                            |this| this.eval_block_to_mir(then)
-                        )
-                    });
-                let (r#else, else_res) =
-                    self.with_conditional(true, |this| {
-                        this.with_comptime_assignment(
-                            ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
-                            |this| this.eval_block_to_mir(r#else)
-                        )
-                    });
+                let (then, then_res) = self.with_conditional(true, |this| {
+                    this.with_comptime_assignment(
+                        ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
+                        |this| this.eval_block_to_mir(then),
+                    )
+                });
+                let (r#else, else_res) = self.with_conditional(true, |this| {
+                    this.with_comptime_assignment(
+                        ComptimeVarAssignment::Blocked { forced_by: Some(condition) },
+                        |this| this.eval_block_to_mir(r#else),
+                    )
+                });
 
                 self.emit(mir::Instruction::If {
                     condition: mir_local,
@@ -720,10 +730,10 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             }
         });
         let mir_condition = mir_condition_local?;
-        let (body, body_res) = self.with_comptime_assignment(
-            ComptimeVarAssignment::Blocked { forced_by: None },
-            |this| this.eval_block_to_mir(body)
-        );
+        let (body, body_res) = self
+            .with_comptime_assignment(ComptimeVarAssignment::Blocked { forced_by: None }, |this| {
+                this.eval_block_to_mir(body)
+            });
         match body_res {
             Err(err @ (Diverge::ControlFlowPoisoned | Diverge::ComptimeQuotaExhausted)) => {
                 return Err(err);

--- a/plankc/frontend/hir-eval/src/scope.rs
+++ b/plankc/frontend/hir-eval/src/scope.rs
@@ -533,9 +533,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
 
     pub fn eval_instr(&mut self, instr: hir::Instruction) -> Result<(), Diverge> {
         match instr.kind {
-            InstructionKind::Set { local, r#type, expr, .. } => {
-                self.eval_set(local, r#type, expr)?
-            }
+            InstructionKind::Set { local, r#type, expr } => self.eval_set(local, r#type, expr)?,
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
                 if comptime {
                     self.eval_comptime_set_mut(local, r#type, expr)?

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3096,7 +3096,7 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
             4 |     if b == 0 {
             5 |         x = x + "foo";
               |             ^^^^^^^^^ assignment in implicit runtime context
-            "#
+            "#,
         ],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3005,3 +3005,119 @@ fn scoped_set_eval_in_branch() {
         "#,
     );
 }
+
+#[test]
+fn test_comptime_var_assigned_in_implicit_comptime_context() {
+    assert_lowers_to(
+        std_project(
+            r#"
+            const MY_CONST = 7;
+
+            init {
+                comptime let mut x = 2;
+
+                if MY_CONST > x {
+                    x = x + 1;
+                    @evm_revert(@malloc_zeroed(x), x);
+                } else {
+                    x = x + 2;
+                    @evm_revert(@malloc_zeroed(x), x);
+                }
+            }
+        "#,
+        ),
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 3
+            %1 : memptr = @malloc_zeroed(%0)
+            %2 : u256 = 3
+            %3 : never = @evm_revert(%1, %2)
+        }
+        "#,
+    );
+}
+
+#[test]
+fn test_comptime_var_referenced_in_explit_comptime_context() {
+    assert_lowers_to(
+        std_project(
+            r#"
+            const MY_CONST = 7;
+
+            init {
+                comptime let mut x = 2;
+
+                let y = comptime {
+                    MY_CONST + x
+                };
+
+                @evm_revert(@malloc_zeroed(y), y);
+            }
+        "#,
+        ),
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 9
+            %1 : memptr = @malloc_zeroed(%0)
+            %2 : u256 = 9
+            %3 : never = @evm_revert(%1, %2)
+        }
+        "#,
+    );
+}
+
+#[test]
+fn test_comptime_var_assigned_in_implicit_runtime_context() {
+    assert_lowers_to(
+        std_project(
+            r#"
+            init {
+                let b = @evm_calldataload(0);
+                comptime let mut x = 34;
+                if b == 0 {
+                    x = x + 1;
+                }
+                @evm_stop();
+            }
+        "#,
+        ),
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 0
+            %1 : u256 = @evm_calldataload(%0)
+            %2 : u256 = %1
+            %3 : u256 = 0
+            %4 : bool = @evm_eq(%2, %3)
+            if %4 {
+                %5 : void = ()
+            } else {
+                %5 : void = ()
+            }
+            %6 : void = %5
+            %7 : never = @evm_stop()
+        }
+
+
+        error: assignment to mutable comptime variable in implicit runtime context
+         --> /Users/vincent/code/plank-monorepo/plankc/scratch2.plk:5:13
+          |
+        3 |     comptime let mut x = 34;
+          |                          -- comptime mutable variable defined here
+        4 |     if b == 0 {
+        5 |         x = x + 1;
+          |             ^^^^^ assignment in implicit runtime context
+          |
+        note: runtime evaluation forced here
+         --> /Users/vincent/code/plank-monorepo/plankc/scratch2.plk:4:8
+          |
+        4 |     if b == 0 {
+          |        ^^^^^^^
+        "#,
+    );
+}

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3040,7 +3040,7 @@ fn test_comptime_var_assigned_in_implicit_comptime_context() {
 }
 
 #[test]
-fn test_comptime_var_referenced_in_explit_comptime_context() {
+fn test_comptime_var_referenced_in_explicit_comptime_context() {
     assert_lowers_to(
         std_project(
             r#"
@@ -3072,7 +3072,7 @@ fn test_comptime_var_referenced_in_explit_comptime_context() {
 
 #[test]
 fn test_comptime_var_assigned_in_implicit_runtime_context() {
-    assert_lowers_to(
+    assert_diagnostics(
         std_project(
             r#"
             init {
@@ -3085,27 +3085,9 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
             }
         "#,
         ),
-        r#"
-        ==== Functions ====
-        ; init
-        @fn0() -> never {
-            %0 : u256 = 0
-            %1 : u256 = @evm_calldataload(%0)
-            %2 : u256 = %1
-            %3 : u256 = 0
-            %4 : bool = @evm_eq(%2, %3)
-            if %4 {
-                %5 : void = ()
-            } else {
-                %5 : void = ()
-            }
-            %6 : void = %5
-            %7 : never = @evm_stop()
-        }
-
-
+        &[r#"
         error: assignment to mutable comptime variable in implicit runtime context
-         --> /Users/vincent/code/plank-monorepo/plankc/scratch2.plk:5:13
+         --> main.plk:5:13
           |
         3 |     comptime let mut x = 34;
           |                          -- comptime mutable variable defined here
@@ -3114,10 +3096,10 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
           |             ^^^^^ assignment in implicit runtime context
           |
         note: runtime evaluation forced here
-         --> /Users/vincent/code/plank-monorepo/plankc/scratch2.plk:4:8
+         --> main.plk:4:8
           |
         4 |     if b == 0 {
           |        ^^^^^^^
-        "#,
+        "#],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3094,12 +3094,6 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
         4 |     if b == 0 {
         5 |         x = x + 1;
           |             ^^^^^ assignment in implicit runtime context
-          |
-        note: runtime evaluation forced here
-         --> main.plk:4:8
-          |
-        4 |     if b == 0 {
-          |        ^^^^^^^
         "#],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3007,6 +3007,32 @@ fn scoped_set_eval_in_branch() {
 }
 
 #[test]
+fn test_comptime_var_assigned_in_explicit_comptime_context() {
+    assert_lowers_to(
+        std_project(
+            r#"
+            init {
+                comptime let mut x = 34;
+                let mut b = comptime {
+                    x = x + 1;
+                    x
+                };
+                @evm_stop();
+            }
+            "#,
+        ),
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 35
+            %1 : never = @evm_stop()
+        }
+        "#,
+    );
+}
+
+#[test]
 fn test_comptime_var_assigned_in_implicit_comptime_context() {
     assert_lowers_to(
         std_project(
@@ -3016,13 +3042,14 @@ fn test_comptime_var_assigned_in_implicit_comptime_context() {
             init {
                 comptime let mut x = 2;
 
-                if MY_CONST > x {
+                let mut b = if MY_CONST > x {
                     x = x + 1;
-                    @evm_revert(@malloc_zeroed(x), x);
+                    x
                 } else {
                     x = x + 2;
-                    @evm_revert(@malloc_zeroed(x), x);
-                }
+                    x
+                };
+                @evm_stop();
             }
         "#,
         ),
@@ -3031,40 +3058,7 @@ fn test_comptime_var_assigned_in_implicit_comptime_context() {
         ; init
         @fn0() -> never {
             %0 : u256 = 3
-            %1 : memptr = @malloc_zeroed(%0)
-            %2 : u256 = 3
-            %3 : never = @evm_revert(%1, %2)
-        }
-        "#,
-    );
-}
-
-#[test]
-fn test_comptime_var_referenced_in_explicit_comptime_context() {
-    assert_lowers_to(
-        std_project(
-            r#"
-            const MY_CONST = 7;
-
-            init {
-                comptime let mut x = 2;
-
-                let y = comptime {
-                    MY_CONST + x
-                };
-
-                @evm_revert(@malloc_zeroed(y), y);
-            }
-        "#,
-        ),
-        r#"
-        ==== Functions ====
-        ; init
-        @fn0() -> never {
-            %0 : u256 = 9
-            %1 : memptr = @malloc_zeroed(%0)
-            %2 : u256 = 9
-            %3 : never = @evm_revert(%1, %2)
+            %1 : never = @evm_stop()
         }
         "#,
     );
@@ -3104,5 +3098,32 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
               |             ^^^^^^^^^ assignment in implicit runtime context
             "#
         ],
+    );
+}
+
+#[test]
+fn test_comptime_var_referenced_in_explicit_comptime_context() {
+    assert_lowers_to(
+        std_project(
+            r#"
+            const MY_CONST = 7;
+
+            init {
+                comptime let mut x = 2;
+                let mut y = comptime {
+                    MY_CONST + x
+                };
+                @evm_stop()
+            }
+        "#,
+        ),
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 9
+            %1 : never = @evm_stop()
+        }
+        "#,
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -3079,21 +3079,30 @@ fn test_comptime_var_assigned_in_implicit_runtime_context() {
                 let b = @evm_calldataload(0);
                 comptime let mut x = 34;
                 if b == 0 {
-                    x = x + 1;
+                    x = x + "foo";
                 }
                 @evm_stop();
             }
         "#,
         ),
-        &[r#"
-        error: assignment to mutable comptime variable in implicit runtime context
-         --> main.plk:5:13
-          |
-        3 |     comptime let mut x = 34;
-          |                          -- comptime mutable variable defined here
-        4 |     if b == 0 {
-        5 |         x = x + 1;
-          |             ^^^^^ assignment in implicit runtime context
-        "#],
+        &[
+            r#"
+            error: mismatched types
+             --> main.plk:5:13
+              |
+            5 |         x = x + "foo";
+              |             ^^^^^^^^^ expected `u256`, got `cbytes`
+            "#,
+            r#"
+            error: assignment to mutable comptime variable in implicit runtime context
+             --> main.plk:5:13
+              |
+            3 |     comptime let mut x = 34;
+              |                          -- comptime mutable variable defined here
+            4 |     if b == 0 {
+            5 |         x = x + "foo";
+              |             ^^^^^^^^^ assignment in implicit runtime context
+            "#
+        ],
     );
 }

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -187,11 +187,8 @@ impl<'a> DisplayHir<'a> {
                 self.fmt_expr(f, expr)?;
                 writeln!(f)
             }
-            InstructionKind::Assign { target, expr: value, comptime } => {
+            InstructionKind::Assign { target, expr: value } => {
                 write!(f, "{pad}")?;
-                if comptime {
-                    write!(f, "[comptime] ")?;
-                }
                 self.fmt_local(f, target)?;
                 write!(f, " := ")?;
                 self.fmt_expr(f, value)?;

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -145,7 +145,6 @@ impl<'a> DisplayHir<'a> {
         local: LocalId,
         r#type: Option<LocalId>,
         expr: Expr,
-        mutable: bool,
     ) -> fmt::Result {
         let pad = "    ".repeat(indent);
         write!(f, "{pad}")?;
@@ -154,7 +153,31 @@ impl<'a> DisplayHir<'a> {
             write!(f, " : ")?;
             self.fmt_local(f, r#type)?;
         }
-        write!(f, " {}= ", if mutable { "[mut]" } else { "" })?;
+        write!(f, " = ")?;
+        self.fmt_expr(f, expr)?;
+        writeln!(f)
+    }
+
+    fn fmt_set_mut(
+        &self,
+        f: &mut Formatter<'_>,
+        indent: usize,
+        local: LocalId,
+        r#type: Option<LocalId>,
+        expr: Expr,
+        comptime: bool,
+    ) -> fmt::Result {
+        let pad = "    ".repeat(indent);
+        write!(f, "{pad}")?;
+        if comptime {
+            write!(f, "[comptime] ")?;
+        }
+        self.fmt_local(f, local)?;
+        if let Some(r#type) = r#type {
+            write!(f, " : ")?;
+            self.fmt_local(f, r#type)?;
+        }
+        write!(f, " [mut]= ")?;
         self.fmt_expr(f, expr)?;
         writeln!(f)
     }
@@ -168,10 +191,10 @@ impl<'a> DisplayHir<'a> {
         let pad = "    ".repeat(indent);
         match instr {
             InstructionKind::Set { local, r#type, expr } => {
-                self.fmt_set(f, indent, local, r#type, expr, false)
+                self.fmt_set(f, indent, local, r#type, expr)
             }
-            InstructionKind::SetMut { local, r#type, expr } => {
-                self.fmt_set(f, indent, local, r#type, expr, true)
+            InstructionKind::SetMut { local, r#type, expr, comptime } => {
+                self.fmt_set_mut(f, indent, local, r#type, expr, comptime)
             }
             InstructionKind::BranchSet { local, expr } => {
                 write!(f, "{pad}")?;
@@ -180,8 +203,11 @@ impl<'a> DisplayHir<'a> {
                 self.fmt_expr(f, expr)?;
                 writeln!(f)
             }
-            InstructionKind::Assign { target, expr: value } => {
+            InstructionKind::Assign { target, expr: value, comptime } => {
                 write!(f, "{pad}")?;
+                if comptime {
+                    write!(f, "[comptime] ")?;
+                }
                 self.fmt_local(f, target)?;
                 write!(f, " := ")?;
                 self.fmt_expr(f, value)?;

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -6,6 +6,11 @@ use std::fmt::{self, Display, Formatter};
 
 const DISPLAY_AS_HEX_THRESHOLD: U256 = uint!(100_000_U256);
 
+enum SetKind {
+    Immutable,
+    Mutable { comptime: bool },
+}
+
 pub struct DisplayHir<'a> {
     hir: &'a Hir,
     values: &'a ValueInterner,
@@ -145,9 +150,12 @@ impl<'a> DisplayHir<'a> {
         local: LocalId,
         r#type: Option<LocalId>,
         expr: Expr,
-        mutable: bool,
-        comptime: bool,
+        kind: SetKind,
     ) -> fmt::Result {
+        let (comptime, marker) = match kind {
+            SetKind::Immutable => (false, ""),
+            SetKind::Mutable { comptime } => (comptime, "[mut]"),
+        };
         let pad = "    ".repeat(indent);
         write!(f, "{pad}")?;
         if comptime {
@@ -158,7 +166,7 @@ impl<'a> DisplayHir<'a> {
             write!(f, " : ")?;
             self.fmt_local(f, r#type)?;
         }
-        write!(f, " {}= ", if mutable { "[mut]" } else { "" })?;
+        write!(f, " {marker}= ")?;
         self.fmt_expr(f, expr)?;
         writeln!(f)
     }
@@ -172,10 +180,10 @@ impl<'a> DisplayHir<'a> {
         let pad = "    ".repeat(indent);
         match instr {
             InstructionKind::Set { local, r#type, expr } => {
-                self.fmt_set(f, indent, local, r#type, expr, false, false)
+                self.fmt_set(f, indent, local, r#type, expr, SetKind::Immutable)
             }
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
-                self.fmt_set(f, indent, local, r#type, expr, true, comptime)
+                self.fmt_set(f, indent, local, r#type, expr, SetKind::Mutable { comptime })
             }
             InstructionKind::BranchSet { local, expr } => {
                 write!(f, "{pad}")?;

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -158,7 +158,7 @@ impl<'a> DisplayHir<'a> {
             write!(f, " : ")?;
             self.fmt_local(f, r#type)?;
         }
-        write!(f, " {}= ", if mutable { "[mut]" } else { "" } )?;
+        write!(f, " {}= ", if mutable { "[mut]" } else { "" })?;
         self.fmt_expr(f, expr)?;
         writeln!(f)
     }

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -6,11 +6,6 @@ use std::fmt::{self, Display, Formatter};
 
 const DISPLAY_AS_HEX_THRESHOLD: U256 = uint!(100_000_U256);
 
-enum SetKind {
-    Immutable,
-    Mutable { comptime: bool },
-}
-
 pub struct DisplayHir<'a> {
     hir: &'a Hir,
     values: &'a ValueInterner,
@@ -150,11 +145,11 @@ impl<'a> DisplayHir<'a> {
         local: LocalId,
         r#type: Option<LocalId>,
         expr: Expr,
-        kind: SetKind,
+        kind: BindingMode,
     ) -> fmt::Result {
         let (comptime, marker) = match kind {
-            SetKind::Immutable => (false, ""),
-            SetKind::Mutable { comptime } => (comptime, "[mut]"),
+            BindingMode::Immutable => (false, ""),
+            BindingMode::Mutable { comptime } => (comptime, "[mut]"),
         };
         let pad = "    ".repeat(indent);
         write!(f, "{pad}")?;
@@ -180,10 +175,10 @@ impl<'a> DisplayHir<'a> {
         let pad = "    ".repeat(indent);
         match instr {
             InstructionKind::Set { local, r#type, expr } => {
-                self.fmt_set(f, indent, local, r#type, expr, SetKind::Immutable)
+                self.fmt_set(f, indent, local, r#type, expr, BindingMode::Immutable)
             }
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
-                self.fmt_set(f, indent, local, r#type, expr, SetKind::Mutable { comptime })
+                self.fmt_set(f, indent, local, r#type, expr, BindingMode::Mutable { comptime })
             }
             InstructionKind::BranchSet { local, expr } => {
                 write!(f, "{pad}")?;

--- a/plankc/frontend/hir/src/display.rs
+++ b/plankc/frontend/hir/src/display.rs
@@ -145,26 +145,7 @@ impl<'a> DisplayHir<'a> {
         local: LocalId,
         r#type: Option<LocalId>,
         expr: Expr,
-    ) -> fmt::Result {
-        let pad = "    ".repeat(indent);
-        write!(f, "{pad}")?;
-        self.fmt_local(f, local)?;
-        if let Some(r#type) = r#type {
-            write!(f, " : ")?;
-            self.fmt_local(f, r#type)?;
-        }
-        write!(f, " = ")?;
-        self.fmt_expr(f, expr)?;
-        writeln!(f)
-    }
-
-    fn fmt_set_mut(
-        &self,
-        f: &mut Formatter<'_>,
-        indent: usize,
-        local: LocalId,
-        r#type: Option<LocalId>,
-        expr: Expr,
+        mutable: bool,
         comptime: bool,
     ) -> fmt::Result {
         let pad = "    ".repeat(indent);
@@ -177,7 +158,7 @@ impl<'a> DisplayHir<'a> {
             write!(f, " : ")?;
             self.fmt_local(f, r#type)?;
         }
-        write!(f, " [mut]= ")?;
+        write!(f, " {}= ", if mutable { "[mut]" } else { "" } )?;
         self.fmt_expr(f, expr)?;
         writeln!(f)
     }
@@ -191,10 +172,10 @@ impl<'a> DisplayHir<'a> {
         let pad = "    ".repeat(indent);
         match instr {
             InstructionKind::Set { local, r#type, expr } => {
-                self.fmt_set(f, indent, local, r#type, expr)
+                self.fmt_set(f, indent, local, r#type, expr, false, false)
             }
             InstructionKind::SetMut { local, r#type, expr, comptime } => {
-                self.fmt_set_mut(f, indent, local, r#type, expr, comptime)
+                self.fmt_set(f, indent, local, r#type, expr, true, comptime)
             }
             InstructionKind::BranchSet { local, expr } => {
                 write!(f, "{pad}")?;

--- a/plankc/frontend/hir/src/lib.rs
+++ b/plankc/frontend/hir/src/lib.rs
@@ -95,10 +95,6 @@ impl BindingMode {
     pub fn is_mutable(self) -> bool {
         matches!(self, BindingMode::Mutable { .. })
     }
-
-    pub fn is_comptime(self) -> bool {
-        matches!(self, BindingMode::Mutable { comptime: true })
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -125,7 +121,6 @@ pub enum InstructionKind {
         expr: Expr,
     },
     Assign {
-        comptime: bool,
         target: LocalId,
         expr: Expr,
     },

--- a/plankc/frontend/hir/src/lib.rs
+++ b/plankc/frontend/hir/src/lib.rs
@@ -79,6 +79,28 @@ impl ExprKind {
     pub const POISON: Self = ExprKind::Value(Err(Poisoned));
 }
 
+/// How a `let` binding behaves. An immutable binding is never `comptime`
+/// (an immutable `comptime let` is redundant), so that state is unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingMode {
+    Immutable,
+    Mutable { comptime: bool },
+}
+
+impl BindingMode {
+    pub fn new(mutable: bool, comptime: bool) -> Self {
+        if mutable { BindingMode::Mutable { comptime } } else { BindingMode::Immutable }
+    }
+
+    pub fn is_mutable(self) -> bool {
+        matches!(self, BindingMode::Mutable { .. })
+    }
+
+    pub fn is_comptime(self) -> bool {
+        matches!(self, BindingMode::Mutable { comptime: true })
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum InstructionKind {
     Param {

--- a/plankc/frontend/hir/src/lib.rs
+++ b/plankc/frontend/hir/src/lib.rs
@@ -97,11 +97,13 @@ pub enum InstructionKind {
         expr: Expr,
     },
     SetMut {
+        comptime: bool,
         local: LocalId,
         r#type: Option<LocalId>,
         expr: Expr,
     },
     Assign {
+        comptime: bool,
         target: LocalId,
         expr: Expr,
     },

--- a/plankc/frontend/hir/src/lib.rs
+++ b/plankc/frontend/hir/src/lib.rs
@@ -79,8 +79,6 @@ impl ExprKind {
     pub const POISON: Self = ExprKind::Value(Err(Poisoned));
 }
 
-/// How a `let` binding behaves. An immutable binding is never `comptime`
-/// (an immutable `comptime let` is redundant), so that state is unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingMode {
     Immutable,

--- a/plankc/frontend/hir/src/lowerer/diagnostics.rs
+++ b/plankc/frontend/hir/src/lowerer/diagnostics.rs
@@ -1,7 +1,6 @@
 use plank_parser::lexer::{Token, TokenSpan};
 use plank_session::{
-    Annotations, Builtin, Claim, ClaimBuilder, Diagnostic, Element, Level, Session, SourceId,
-    SourceSpan, StrId,
+    Annotations, Builtin, Claim, ClaimBuilder, Diagnostic, Element, Level, Session, SourceId, SourceSpan, StrId,
 };
 
 use super::BlockLowerer;
@@ -264,6 +263,17 @@ impl BlockLowerer<'_> {
                     .primary(self.lexed.tokens_src_span(return_span), "not allowed here"),
             )
             .emit(*self.session.borrow_mut());
+    }
+
+    pub fn emit_comptime_let_redundant_in_comptime_scope(&self, span: TokenSpan) {
+        let source_span = self.lexed.tokens_src_span(span);
+        Diagnostic::error(format!("'comptime let' is redundant in comptime scope"))
+            .element(
+                Annotations::new(self.source_id)
+                    .no_label(source_span, plank_session::AnnotationKind::Primary)
+            )
+            .emit(*self.session.borrow_mut());
+
     }
 }
 

--- a/plankc/frontend/hir/src/lowerer/diagnostics.rs
+++ b/plankc/frontend/hir/src/lowerer/diagnostics.rs
@@ -265,16 +265,6 @@ impl BlockLowerer<'_> {
             )
             .emit(*self.session.borrow_mut());
     }
-
-    pub fn emit_comptime_let_redundant_in_comptime_scope(&self, span: TokenSpan) {
-        let source_span = self.lexed.tokens_src_span(span);
-        Diagnostic::error("'comptime let' is redundant in comptime scope")
-            .element(
-                Annotations::new(self.source_id)
-                    .no_label(source_span, plank_session::AnnotationKind::Primary),
-            )
-            .emit(*self.session.borrow_mut());
-    }
 }
 
 pub(super) fn error_duplicate_const(

--- a/plankc/frontend/hir/src/lowerer/diagnostics.rs
+++ b/plankc/frontend/hir/src/lowerer/diagnostics.rs
@@ -1,6 +1,7 @@
 use plank_parser::lexer::{Token, TokenSpan};
 use plank_session::{
-    Annotations, Builtin, Claim, ClaimBuilder, Diagnostic, Element, Level, Session, SourceId, SourceSpan, StrId,
+    Annotations, Builtin, Claim, ClaimBuilder, Diagnostic, Element, Level, Session, SourceId,
+    SourceSpan, StrId,
 };
 
 use super::BlockLowerer;
@@ -267,13 +268,12 @@ impl BlockLowerer<'_> {
 
     pub fn emit_comptime_let_redundant_in_comptime_scope(&self, span: TokenSpan) {
         let source_span = self.lexed.tokens_src_span(span);
-        Diagnostic::error(format!("'comptime let' is redundant in comptime scope"))
+        Diagnostic::error("'comptime let' is redundant in comptime scope")
             .element(
                 Annotations::new(self.source_id)
-                    .no_label(source_span, plank_session::AnnotationKind::Primary)
+                    .no_label(source_span, plank_session::AnnotationKind::Primary),
             )
             .emit(*self.session.borrow_mut());
-
     }
 }
 

--- a/plankc/frontend/hir/src/lowerer/diagnostics.rs
+++ b/plankc/frontend/hir/src/lowerer/diagnostics.rs
@@ -49,6 +49,23 @@ impl BlockLowerer<'_> {
             .emit(*self.session.borrow_mut());
     }
 
+    pub(crate) fn error_immutable_comptime_let(&self, name: StrId, span: TokenSpan) {
+        let source_span = self.lexed.tokens_src_span(span);
+        let name_str = self.lookup_name(name);
+        Diagnostic::error("immutable `comptime let` is not allowed")
+            .primary(
+                self.source_id,
+                source_span,
+                "`comptime` on a `let` is only meaningful with `mut`",
+            )
+            .note("an immutable `comptime let` is redundant with a plain `let`")
+            .help(format!("remove `comptime` to bind `let {name_str} = ...`"))
+            .help(format!(
+                "use `comptime let mut {name_str}` to declare a compile-time mutable variable"
+            ))
+            .emit(*self.session.borrow_mut());
+    }
+
     pub(crate) fn error_multiple_init_blocks(&self, current: TokenSpan, previous: TokenSpan) {
         self.error_multiple_blocks("init", current, previous);
     }

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -23,7 +23,7 @@ use crate::*;
 struct ScopedLocal {
     name: StrId,
     id: LocalId,
-    mode: BindingMode,
+    mutable: bool,
     span: Option<TokenSpan>,
 }
 
@@ -84,7 +84,6 @@ struct BlockLowerer<'a> {
 
     lexed: &'a Lexed,
     source_id: SourceId,
-    comptime: bool,
 }
 enum ShortCircuitOp {
     And,
@@ -181,24 +180,19 @@ impl BlockLowerer<'_> {
         debug_assert!(self.captures_buf.is_empty());
     }
 
-    fn alloc_local(&mut self, name: StrId, mode: BindingMode, span: TokenSpan) -> LocalId {
+    fn alloc_local(&mut self, name: StrId, mutable: bool, span: TokenSpan) -> LocalId {
         if TypeId::resolve_primitive(name).is_some() {
             self.error_shadowing_primitive_type(name, span);
         }
 
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal { name, id, mode, span: Some(span) });
+        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable, span: Some(span) });
         id
     }
 
     fn alloc_anonymous_local(&mut self, name: StrId) -> LocalId {
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal {
-            name,
-            id,
-            mode: BindingMode::Immutable,
-            span: None,
-        });
+        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable: false, span: None });
         id
     }
 
@@ -543,7 +537,7 @@ impl BlockLowerer<'_> {
     }
 
     fn add_param_to_scope_as_local(&mut self, param: ast::Param<'_>) -> LocalId {
-        self.alloc_local(param.name, BindingMode::Immutable, param.name_span())
+        self.alloc_local(param.name, false, param.name_span())
     }
 
     fn lower_fn_def(&mut self, fn_def: ast::FnDef<'_>) -> FnDefId {
@@ -568,7 +562,7 @@ impl BlockLowerer<'_> {
                             self.error_duplicate_param_any_type_capture(name, name_span, prev.span);
                             ParamType::Poisoned
                         } else {
-                            let capture = self.alloc_local(name, BindingMode::Immutable, name_span);
+                            let capture = self.alloc_local(name, false, name_span);
                             ParamType::Any { capture }
                         }
                     }
@@ -726,7 +720,7 @@ impl BlockLowerer<'_> {
                 let mode = BindingMode::new(let_stmt.mutable, let_stmt.comptime);
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
-                let local = self.alloc_local(let_stmt.name, mode, let_stmt.name_span);
+                let local = self.alloc_local(let_stmt.name, mode.is_mutable(), let_stmt.name_span);
                 let r#type =
                     let_stmt.type_expr().map(|type_expr| self.lower_expr_to_local(type_expr));
 
@@ -758,7 +752,7 @@ impl BlockLowerer<'_> {
                     self.error_unresolved_identifier(name, span);
                     return;
                 };
-                if !entry.mode.is_mutable() {
+                if !entry.mutable {
                     self.error_assignment_to_immutable(
                         name,
                         span,
@@ -769,8 +763,7 @@ impl BlockLowerer<'_> {
                 let target = entry.id;
                 let value = self.lower_expr(assign_stmt.value());
 
-                let comptime = if self.comptime { false } else { entry.mode.is_comptime() };
-                self.emit(InstructionKind::Assign { target, expr: value, comptime });
+                self.emit(InstructionKind::Assign { target, expr: value });
             }
             Statement::While(while_stmt) => {
                 let span = while_stmt.node().span();
@@ -819,7 +812,6 @@ pub fn lower(project: &ParsedProject, values: &mut ValueInterner, session: &mut 
 
         lexed: &project.parsed_sources[SourceId::ROOT].lexed,
         source_id: SourceId::ROOT,
-        comptime: false,
     };
 
     for (source_id, source) in project.parsed_sources.enumerate_idx() {

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -480,16 +480,16 @@ impl BlockLowerer<'_> {
             ast::Expr::ComptimeBlock(block) => {
                 let result = self.alloc_temp();
                 let body = self.create_sub_block(block.node().span(), |this| {
-                        for stmt in block.statements() {
-                            this.lower_statement(stmt);
+                    for stmt in block.statements() {
+                        this.lower_statement(stmt);
+                    }
+                    let expr = match block.end_expr() {
+                        Some(e) => this.lower_expr(e),
+                        None => {
+                            let span = block.node().span();
+                            this.expr(ExprKind::VOID, span)
                         }
-                        let expr = match block.end_expr() {
-                            Some(e) => this.lower_expr(e),
-                            None => {
-                                let span = block.node().span();
-                                this.expr(ExprKind::VOID, span)
-                            }
-                        };
+                    };
                     this.emit(InstructionKind::Set { local: result, r#type: None, expr });
                 });
 
@@ -734,6 +734,9 @@ impl BlockLowerer<'_> {
     fn lower_statement(&mut self, stmt: Statement<'_>) {
         match stmt {
             Statement::Let(let_stmt) => {
+                if let_stmt.comptime && !let_stmt.mutable {
+                    self.error_immutable_comptime_let(let_stmt.name, let_stmt.span());
+                }
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
                 let local = self.alloc_local(

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -182,19 +182,37 @@ impl BlockLowerer<'_> {
         debug_assert!(self.captures_buf.is_empty());
     }
 
-    fn alloc_local(&mut self, name: StrId, mutable: bool, comptime: bool, span: TokenSpan) -> LocalId {
+    fn alloc_local(
+        &mut self,
+        name: StrId,
+        mutable: bool,
+        comptime: bool,
+        span: TokenSpan,
+    ) -> LocalId {
         if TypeId::resolve_primitive(name).is_some() {
             self.error_shadowing_primitive_type(name, span);
         }
 
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable, comptime, span: Some(span) });
+        self.scoped_locals_stack.push(ScopedLocal {
+            name,
+            id,
+            mutable,
+            comptime,
+            span: Some(span),
+        });
         id
     }
 
     fn alloc_anonymous_local(&mut self, name: StrId) -> LocalId {
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable: false, comptime: false, span: None });
+        self.scoped_locals_stack.push(ScopedLocal {
+            name,
+            id,
+            mutable: false,
+            comptime: false,
+            span: None,
+        });
         id
     }
 
@@ -723,10 +741,14 @@ impl BlockLowerer<'_> {
                 }
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
-                let local = self.alloc_local(let_stmt.name, let_stmt.mutable, let_stmt.comptime, let_stmt.name_span);
+                let local = self.alloc_local(
+                    let_stmt.name,
+                    let_stmt.mutable,
+                    let_stmt.comptime,
+                    let_stmt.name_span,
+                );
                 let r#type =
                     let_stmt.type_expr().map(|type_expr| self.lower_expr_to_local(type_expr));
-
 
                 self.emit(if let_stmt.mutable {
                     InstructionKind::SetMut { local, r#type, expr, comptime: let_stmt.comptime }
@@ -766,11 +788,7 @@ impl BlockLowerer<'_> {
                 let target = entry.id;
                 let value = self.lower_expr(assign_stmt.value());
 
-                let comptime = if self.comptime {
-                    false
-                } else {
-                    entry.comptime
-                };
+                let comptime = if self.comptime { false } else { entry.comptime };
                 self.emit(InstructionKind::Assign { target, expr: value, comptime });
             }
             Statement::While(while_stmt) => {

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -24,6 +24,7 @@ struct ScopedLocal {
     name: StrId,
     id: LocalId,
     mutable: bool,
+    comptime: bool,
     span: Option<TokenSpan>,
 }
 
@@ -84,6 +85,7 @@ struct BlockLowerer<'a> {
 
     lexed: &'a Lexed,
     source_id: SourceId,
+    comptime: bool,
 }
 enum ShortCircuitOp {
     And,
@@ -180,19 +182,19 @@ impl BlockLowerer<'_> {
         debug_assert!(self.captures_buf.is_empty());
     }
 
-    fn alloc_local(&mut self, name: StrId, mutable: bool, span: TokenSpan) -> LocalId {
+    fn alloc_local(&mut self, name: StrId, mutable: bool, comptime: bool, span: TokenSpan) -> LocalId {
         if TypeId::resolve_primitive(name).is_some() {
             self.error_shadowing_primitive_type(name, span);
         }
 
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable, span: Some(span) });
+        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable, comptime, span: Some(span) });
         id
     }
 
     fn alloc_anonymous_local(&mut self, name: StrId) -> LocalId {
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable: false, span: None });
+        self.scoped_locals_stack.push(ScopedLocal { name, id, mutable: false, comptime: false, span: None });
         id
     }
 
@@ -460,6 +462,7 @@ impl BlockLowerer<'_> {
             ast::Expr::ComptimeBlock(block) => {
                 let result = self.alloc_temp();
                 let body = self.create_sub_block(block.node().span(), |this| {
+                    this.comptime = true;
                     for stmt in block.statements() {
                         this.lower_statement(stmt);
                     }
@@ -470,6 +473,7 @@ impl BlockLowerer<'_> {
                             this.expr(ExprKind::VOID, span)
                         }
                     };
+                    this.comptime = false;
                     this.emit(InstructionKind::Set { local: result, r#type: None, expr });
                 });
 
@@ -537,7 +541,7 @@ impl BlockLowerer<'_> {
     }
 
     fn add_param_to_scope_as_local(&mut self, param: ast::Param<'_>) -> LocalId {
-        self.alloc_local(param.name, false, param.name_span())
+        self.alloc_local(param.name, false, false, param.name_span())
     }
 
     fn lower_fn_def(&mut self, fn_def: ast::FnDef<'_>) -> FnDefId {
@@ -562,7 +566,7 @@ impl BlockLowerer<'_> {
                             self.error_duplicate_param_any_type_capture(name, name_span, prev.span);
                             ParamType::Poisoned
                         } else {
-                            let capture = self.alloc_local(name, false, name_span);
+                            let capture = self.alloc_local(name, false, false, name_span);
                             ParamType::Any { capture }
                         }
                     }
@@ -714,13 +718,18 @@ impl BlockLowerer<'_> {
     fn lower_statement(&mut self, stmt: Statement<'_>) {
         match stmt {
             Statement::Let(let_stmt) => {
+                if self.comptime && let_stmt.comptime {
+                    self.emit_comptime_let_redundant_in_comptime_scope(let_stmt.name_span);
+                }
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
-                let local = self.alloc_local(let_stmt.name, let_stmt.mutable, let_stmt.name_span);
+                let local = self.alloc_local(let_stmt.name, let_stmt.mutable, let_stmt.comptime, let_stmt.name_span);
                 let r#type =
                     let_stmt.type_expr().map(|type_expr| self.lower_expr_to_local(type_expr));
+
+
                 self.emit(if let_stmt.mutable {
-                    InstructionKind::SetMut { local, r#type, expr }
+                    InstructionKind::SetMut { local, r#type, expr, comptime: let_stmt.comptime }
                 } else {
                     InstructionKind::Set { local, r#type, expr }
                 });
@@ -756,7 +765,13 @@ impl BlockLowerer<'_> {
                 }
                 let target = entry.id;
                 let value = self.lower_expr(assign_stmt.value());
-                self.emit(InstructionKind::Assign { target, expr: value });
+
+                let comptime = if self.comptime {
+                    false
+                } else {
+                    entry.comptime
+                };
+                self.emit(InstructionKind::Assign { target, expr: value, comptime });
             }
             Statement::While(while_stmt) => {
                 let span = while_stmt.node().span();
@@ -805,6 +820,7 @@ pub fn lower(project: &ParsedProject, values: &mut ValueInterner, session: &mut 
 
         lexed: &project.parsed_sources[SourceId::ROOT].lexed,
         source_id: SourceId::ROOT,
+        comptime: false,
     };
 
     for (source_id, source) in project.parsed_sources.enumerate_idx() {

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -329,13 +329,6 @@ impl BlockLowerer<'_> {
         self.instructions_buf.push(Instruction { kind });
     }
 
-    fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
-        let parent_comptime = std::mem::replace(&mut self.comptime, true);
-        let result = inner(self);
-        self.comptime = parent_comptime;
-        result
-    }
-
     fn flush_instructions_from(&mut self, start: usize, span: SourceSpan) -> BlockId {
         let block_id = self.builder.block_instrs.push_iter(self.instructions_buf.drain(start..));
         let span_id = self.builder.block_spans.push(Ok(span));
@@ -487,18 +480,16 @@ impl BlockLowerer<'_> {
             ast::Expr::ComptimeBlock(block) => {
                 let result = self.alloc_temp();
                 let body = self.create_sub_block(block.node().span(), |this| {
-                    let expr = this.with_comptime(|this| {
                         for stmt in block.statements() {
                             this.lower_statement(stmt);
                         }
-                        match block.end_expr() {
+                        let expr = match block.end_expr() {
                             Some(e) => this.lower_expr(e),
                             None => {
                                 let span = block.node().span();
                                 this.expr(ExprKind::VOID, span)
                             }
-                        }
-                    });
+                        };
                     this.emit(InstructionKind::Set { local: result, r#type: None, expr });
                 });
 
@@ -743,9 +734,6 @@ impl BlockLowerer<'_> {
     fn lower_statement(&mut self, stmt: Statement<'_>) {
         match stmt {
             Statement::Let(let_stmt) => {
-                if self.comptime && let_stmt.comptime {
-                    self.emit_comptime_let_redundant_in_comptime_scope(let_stmt.name_span);
-                }
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
                 let local = self.alloc_local(

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -329,6 +329,13 @@ impl BlockLowerer<'_> {
         self.instructions_buf.push(Instruction { kind });
     }
 
+    fn with_comptime<R>(&mut self, inner: impl FnOnce(&mut Self) -> R) -> R {
+        let parent_comptime = std::mem::replace(&mut self.comptime, true);
+        let result = inner(self);
+        self.comptime = parent_comptime;
+        result
+    }
+
     fn flush_instructions_from(&mut self, start: usize, span: SourceSpan) -> BlockId {
         let block_id = self.builder.block_instrs.push_iter(self.instructions_buf.drain(start..));
         let span_id = self.builder.block_spans.push(Ok(span));
@@ -480,18 +487,18 @@ impl BlockLowerer<'_> {
             ast::Expr::ComptimeBlock(block) => {
                 let result = self.alloc_temp();
                 let body = self.create_sub_block(block.node().span(), |this| {
-                    this.comptime = true;
-                    for stmt in block.statements() {
-                        this.lower_statement(stmt);
-                    }
-                    let expr = match block.end_expr() {
-                        Some(e) => this.lower_expr(e),
-                        None => {
-                            let span = block.node().span();
-                            this.expr(ExprKind::VOID, span)
+                    let expr = this.with_comptime(|this| {
+                        for stmt in block.statements() {
+                            this.lower_statement(stmt);
                         }
-                    };
-                    this.comptime = false;
+                        match block.end_expr() {
+                            Some(e) => this.lower_expr(e),
+                            None => {
+                                let span = block.node().span();
+                                this.expr(ExprKind::VOID, span)
+                            }
+                        }
+                    });
                     this.emit(InstructionKind::Set { local: result, r#type: None, expr });
                 });
 

--- a/plankc/frontend/hir/src/lowerer/mod.rs
+++ b/plankc/frontend/hir/src/lowerer/mod.rs
@@ -23,8 +23,7 @@ use crate::*;
 struct ScopedLocal {
     name: StrId,
     id: LocalId,
-    mutable: bool,
-    comptime: bool,
+    mode: BindingMode,
     span: Option<TokenSpan>,
 }
 
@@ -182,25 +181,13 @@ impl BlockLowerer<'_> {
         debug_assert!(self.captures_buf.is_empty());
     }
 
-    fn alloc_local(
-        &mut self,
-        name: StrId,
-        mutable: bool,
-        comptime: bool,
-        span: TokenSpan,
-    ) -> LocalId {
+    fn alloc_local(&mut self, name: StrId, mode: BindingMode, span: TokenSpan) -> LocalId {
         if TypeId::resolve_primitive(name).is_some() {
             self.error_shadowing_primitive_type(name, span);
         }
 
         let id = self.next_local_id.get_and_inc();
-        self.scoped_locals_stack.push(ScopedLocal {
-            name,
-            id,
-            mutable,
-            comptime,
-            span: Some(span),
-        });
+        self.scoped_locals_stack.push(ScopedLocal { name, id, mode, span: Some(span) });
         id
     }
 
@@ -209,8 +196,7 @@ impl BlockLowerer<'_> {
         self.scoped_locals_stack.push(ScopedLocal {
             name,
             id,
-            mutable: false,
-            comptime: false,
+            mode: BindingMode::Immutable,
             span: None,
         });
         id
@@ -557,7 +543,7 @@ impl BlockLowerer<'_> {
     }
 
     fn add_param_to_scope_as_local(&mut self, param: ast::Param<'_>) -> LocalId {
-        self.alloc_local(param.name, false, false, param.name_span())
+        self.alloc_local(param.name, BindingMode::Immutable, param.name_span())
     }
 
     fn lower_fn_def(&mut self, fn_def: ast::FnDef<'_>) -> FnDefId {
@@ -582,7 +568,7 @@ impl BlockLowerer<'_> {
                             self.error_duplicate_param_any_type_capture(name, name_span, prev.span);
                             ParamType::Poisoned
                         } else {
-                            let capture = self.alloc_local(name, false, false, name_span);
+                            let capture = self.alloc_local(name, BindingMode::Immutable, name_span);
                             ParamType::Any { capture }
                         }
                     }
@@ -737,21 +723,18 @@ impl BlockLowerer<'_> {
                 if let_stmt.comptime && !let_stmt.mutable {
                     self.error_immutable_comptime_let(let_stmt.name, let_stmt.span());
                 }
+                let mode = BindingMode::new(let_stmt.mutable, let_stmt.comptime);
                 let expr = self.lower_expr(let_stmt.value());
                 // Local allocated *after* to ensure it's not visible to `lower_expr`.
-                let local = self.alloc_local(
-                    let_stmt.name,
-                    let_stmt.mutable,
-                    let_stmt.comptime,
-                    let_stmt.name_span,
-                );
+                let local = self.alloc_local(let_stmt.name, mode, let_stmt.name_span);
                 let r#type =
                     let_stmt.type_expr().map(|type_expr| self.lower_expr_to_local(type_expr));
 
-                self.emit(if let_stmt.mutable {
-                    InstructionKind::SetMut { local, r#type, expr, comptime: let_stmt.comptime }
-                } else {
-                    InstructionKind::Set { local, r#type, expr }
+                self.emit(match mode {
+                    BindingMode::Mutable { comptime } => {
+                        InstructionKind::SetMut { local, r#type, expr, comptime }
+                    }
+                    BindingMode::Immutable => InstructionKind::Set { local, r#type, expr },
                 });
             }
             Statement::Expr(expr) => {
@@ -775,7 +758,7 @@ impl BlockLowerer<'_> {
                     self.error_unresolved_identifier(name, span);
                     return;
                 };
-                if !entry.mutable {
+                if !entry.mode.is_mutable() {
                     self.error_assignment_to_immutable(
                         name,
                         span,
@@ -786,7 +769,7 @@ impl BlockLowerer<'_> {
                 let target = entry.id;
                 let value = self.lower_expr(assign_stmt.value());
 
-                let comptime = if self.comptime { false } else { entry.comptime };
+                let comptime = if self.comptime { false } else { entry.mode.is_comptime() };
                 self.emit(InstructionKind::Assign { target, expr: value, comptime });
             }
             Statement::While(while_stmt) => {

--- a/plankc/frontend/hir/src/tests.rs
+++ b/plankc/frontend/hir/src/tests.rs
@@ -196,6 +196,31 @@ fn test_assign_to_immutable_let() {
 }
 
 #[test]
+fn test_immutable_comptime_let() {
+    let rendered = render_diagnostics(
+        r#"
+        init {
+            comptime let x = 34;
+        }
+        "#,
+    );
+    let expected = dedent_preserve_blank_lines(
+        r#"
+        error: immutable `comptime let` is not allowed
+         --> main.plk:2:5
+          |
+        2 |     comptime let x = 34;
+          |     ^^^^^^^^^^^^^^^^^^^^ `comptime` on a `let` is only meaningful with `mut`
+          |
+          = note: an immutable `comptime let` is redundant with a plain `let`
+          = help: remove `comptime` to bind `let x = ...`
+          = help: use `comptime let mut x` to declare a compile-time mutable variable
+        "#,
+    );
+    pretty_assertions::assert_str_eq!(rendered.trim(), expected.trim());
+}
+
+#[test]
 fn test_return_in_fn_param_type_expression() {
     let rendered = render_diagnostics(
         r#"

--- a/plankc/frontend/parser/src/ast/expr.rs
+++ b/plankc/frontend/parser/src/ast/expr.rs
@@ -498,6 +498,7 @@ pub struct LetStmt<'cst> {
     pub name: StrId,
     pub name_span: TokenSpan,
     pub mutable: bool,
+    pub comptime: bool,
     type_view: Option<NodeView<'cst>>,
     value_view: NodeView<'cst>,
 }
@@ -505,7 +506,7 @@ pub struct LetStmt<'cst> {
 impl<'cst> LetStmt<'cst> {
     /// Returns `Ok(None)` for non-LetStmt nodes, `Err(span)` for malformed LetStmt nodes.
     fn try_new(view: NodeView<'cst>) -> Result<Option<Self>, TokenSpan> {
-        let NodeKind::LetStmt { mutable, typed } = view.kind() else {
+        let NodeKind::LetStmt { mutable, typed, comptime } = view.kind() else {
             return Ok(None);
         };
         let mut children = view.children();
@@ -514,7 +515,7 @@ impl<'cst> LetStmt<'cst> {
         let name = name_view.ident().ok_or(view.span())?;
         let type_view = if typed { Some(children.next().ok_or(view.span())?) } else { None };
         let value_view = children.next().ok_or(view.span())?;
-        Ok(Some(Self { name, name_span, mutable, type_view, value_view }))
+        Ok(Some(Self { name, name_span, mutable, comptime, type_view, value_view }))
     }
 
     pub fn type_expr(&self) -> Option<Expr<'cst>> {

--- a/plankc/frontend/parser/src/ast/expr.rs
+++ b/plankc/frontend/parser/src/ast/expr.rs
@@ -499,6 +499,7 @@ pub struct LetStmt<'cst> {
     pub name_span: TokenSpan,
     pub mutable: bool,
     pub comptime: bool,
+    span: TokenSpan,
     type_view: Option<NodeView<'cst>>,
     value_view: NodeView<'cst>,
 }
@@ -515,7 +516,15 @@ impl<'cst> LetStmt<'cst> {
         let name = name_view.ident().ok_or(view.span())?;
         let type_view = if typed { Some(children.next().ok_or(view.span())?) } else { None };
         let value_view = children.next().ok_or(view.span())?;
-        Ok(Some(Self { name, name_span, mutable, comptime, type_view, value_view }))
+        Ok(Some(Self {
+            name,
+            name_span,
+            mutable,
+            comptime,
+            span: view.span(),
+            type_view,
+            value_view,
+        }))
     }
 
     pub fn type_expr(&self) -> Option<Expr<'cst>> {
@@ -524,6 +533,10 @@ impl<'cst> LetStmt<'cst> {
 
     pub fn value(&self) -> Expr<'cst> {
         Expr::new_unwrap(self.value_view)
+    }
+
+    pub fn span(&self) -> TokenSpan {
+        self.span
     }
 }
 

--- a/plankc/frontend/parser/src/cst/mod.rs
+++ b/plankc/frontend/parser/src/cst/mod.rs
@@ -138,9 +138,12 @@ impl std::fmt::Debug for NodeKind {
             Self::RunBlock => write!(f, "RunBlock"),
             Self::ComptimeBlock => write!(f, "ComptimeBlock"),
             Self::Block => write!(f, "Block"),
-            Self::LetStmt { mutable, typed, comptime } => {
-                f.debug_struct("LetStmt").field("mutable", mutable).field("typed", typed).field("comptime", comptime).finish()
-            }
+            Self::LetStmt { mutable, typed, comptime } => f
+                .debug_struct("LetStmt")
+                .field("mutable", mutable)
+                .field("typed", typed)
+                .field("comptime", comptime)
+                .finish(),
             Self::ReturnStmt => write!(f, "ReturnStmt"),
             Self::AssignStmt => write!(f, "AssignStmt"),
             Self::WhileStmt => write!(f, "WhileStmt"),

--- a/plankc/frontend/parser/src/cst/mod.rs
+++ b/plankc/frontend/parser/src/cst/mod.rs
@@ -78,7 +78,7 @@ pub enum NodeKind {
     // Statements
     ComptimeBlock,
     Block,
-    LetStmt { mutable: bool, typed: bool },
+    LetStmt { mutable: bool, typed: bool, comptime: bool },
     ReturnStmt,
     AssignStmt,
     WhileStmt,
@@ -138,8 +138,8 @@ impl std::fmt::Debug for NodeKind {
             Self::RunBlock => write!(f, "RunBlock"),
             Self::ComptimeBlock => write!(f, "ComptimeBlock"),
             Self::Block => write!(f, "Block"),
-            Self::LetStmt { mutable, typed } => {
-                f.debug_struct("LetStmt").field("mutable", mutable).field("typed", typed).finish()
+            Self::LetStmt { mutable, typed, comptime } => {
+                f.debug_struct("LetStmt").field("mutable", mutable).field("typed", typed).field("comptime", comptime).finish()
             }
             Self::ReturnStmt => write!(f, "ReturnStmt"),
             Self::AssignStmt => write!(f, "AssignStmt"),

--- a/plankc/frontend/parser/src/parser/mod.rs
+++ b/plankc/frontend/parser/src/parser/mod.rs
@@ -853,7 +853,7 @@ impl<'a> Parser<'a> {
             return None;
         };
 
-        return self.finish_parse_stmt(stmt_start, expr);
+        self.finish_parse_stmt(stmt_start, expr)
     }
 
     fn finish_parse_stmt(&mut self, stmt_start: TokenIdx, expr: NodeIdx) -> Option<StmtResult> {
@@ -904,7 +904,7 @@ impl<'a> Parser<'a> {
         self.expect(Token::Semicolon);
 
         let r#let = self.close_node(r#let);
-        return Some(StmtResult::Statement(r#let));
+        Some(StmtResult::Statement(r#let))
     }
 
     fn parse_block(&mut self, block_start: TokenIdx, block_kind: NodeKind) -> NodeIdx {

--- a/plankc/frontend/parser/src/parser/mod.rs
+++ b/plankc/frontend/parser/src/parser/mod.rs
@@ -834,28 +834,16 @@ impl<'a> Parser<'a> {
         }
 
         if self.eat(Token::Let) {
-            let mutable = self.eat(Token::Mut);
-            let mut r#let =
-                self.alloc_node_from(stmt_start, NodeKind::LetStmt { mutable, typed: false });
+            return self.parse_let(stmt_start, false);
+        }
 
-            let name = self.expect_ident();
-            self.push_child(&mut r#let, name);
-
-            if self.eat(Token::Colon) {
-                self.update_kind(r#let, NodeKind::LetStmt { mutable, typed: true });
-                let type_expr = self.parse_expr(ParseExprMode::AllowAll);
-                self.push_child(&mut r#let, type_expr);
+        if self.eat(Token::Comptime) {
+            if self.eat(Token::Let) {
+                return self.parse_let(stmt_start, true);
+            } else {
+                let expr = self.parse_block(stmt_start, NodeKind::ComptimeBlock);
+                self.finish_parse_stmt(stmt_start, expr);
             }
-
-            self.expect(Token::Equals);
-
-            let assign = self.parse_expr(ParseExprMode::AllowAll);
-            self.push_child(&mut r#let, assign);
-
-            self.expect(Token::Semicolon);
-
-            let r#let = self.close_node(r#let);
-            return Some(StmtResult::Statement(r#let));
         }
 
         let Some(expr) = self.try_parse_expr(ParseExprMode::AllowAll) else {
@@ -865,6 +853,10 @@ impl<'a> Parser<'a> {
             return None;
         };
 
+        return self.finish_parse_stmt(stmt_start, expr);
+    }
+
+    fn finish_parse_stmt(&mut self, stmt_start: TokenIdx, expr: NodeIdx) -> Option<StmtResult> {
         if self.eat(Token::Equals) {
             let mut assign = self.alloc_node_from(stmt_start, NodeKind::AssignStmt);
             self.push_child(&mut assign, expr);
@@ -888,6 +880,31 @@ impl<'a> Parser<'a> {
         } else {
             Some(StmtResult::EndExprOrStmt(expr))
         }
+    }
+
+    fn parse_let(&mut self, let_start: TokenIdx, comptime: bool) -> Option<StmtResult> {
+        let mutable = self.eat(Token::Mut);
+        let mut r#let =
+            self.alloc_node_from(let_start, NodeKind::LetStmt { mutable, typed: false, comptime });
+
+        let name = self.expect_ident();
+        self.push_child(&mut r#let, name);
+
+        if self.eat(Token::Colon) {
+            self.update_kind(r#let, NodeKind::LetStmt { mutable, typed: true, comptime });
+            let type_expr = self.parse_expr(ParseExprMode::AllowAll);
+            self.push_child(&mut r#let, type_expr);
+        }
+
+        self.expect(Token::Equals);
+
+        let assign = self.parse_expr(ParseExprMode::AllowAll);
+        self.push_child(&mut r#let, assign);
+
+        self.expect(Token::Semicolon);
+
+        let r#let = self.close_node(r#let);
+        return Some(StmtResult::Statement(r#let));
     }
 
     fn parse_block(&mut self, block_start: TokenIdx, block_kind: NodeKind) -> NodeIdx {

--- a/plankc/frontend/parser/src/parser/mod.rs
+++ b/plankc/frontend/parser/src/parser/mod.rs
@@ -687,7 +687,7 @@ impl<'a> Parser<'a> {
     ) -> Option<NodeIdx> {
         let start = self.skip_trivia_start();
 
-        let mut expr = if let Some(((), rhs, kind)) = self.eat_unary() {
+        let expr = if let Some(((), rhs, kind)) = self.eat_unary() {
             let mut unary = self.alloc_node_from(start, NodeKind::UnaryExpr(kind));
             // TODO: Track recursion
             let expr = self.try_parse_expr_min_bp(mode, rhs).unwrap_or_else(|| {
@@ -701,6 +701,16 @@ impl<'a> Parser<'a> {
             self.try_parse_standalone_expr()?
         };
 
+        Some(self.continue_expr_min_bp(start, expr, mode, min_bp))
+    }
+
+    fn continue_expr_min_bp(
+        &mut self,
+        start: TokenIdx,
+        mut expr: NodeIdx,
+        mode: ParseExprMode,
+        min_bp: OpPriority,
+    ) -> NodeIdx {
         loop {
             if Self::MEMBER_PRIORITY > min_bp && self.eat(Token::Dot) {
                 let mut member = self.alloc_node_from(start, NodeKind::MemberExpr);
@@ -787,7 +797,7 @@ impl<'a> Parser<'a> {
             break;
         }
 
-        Some(expr)
+        expr
     }
 
     // ========================== STATEMENT PARSING ==========================
@@ -840,10 +850,15 @@ impl<'a> Parser<'a> {
         if self.eat(Token::Comptime) {
             if self.eat(Token::Let) {
                 return self.parse_let(stmt_start, true);
-            } else {
-                let expr = self.parse_block(stmt_start, NodeKind::ComptimeBlock);
-                return self.finish_parse_stmt(stmt_start, expr);
             }
+            let block = self.parse_block(stmt_start, NodeKind::ComptimeBlock);
+            let expr = self.continue_expr_min_bp(
+                stmt_start,
+                block,
+                ParseExprMode::AllowAll,
+                OpPriority::ZERO,
+            );
+            return self.finish_parse_stmt(stmt_start, expr);
         }
 
         let Some(expr) = self.try_parse_expr(ParseExprMode::AllowAll) else {

--- a/plankc/frontend/parser/src/parser/mod.rs
+++ b/plankc/frontend/parser/src/parser/mod.rs
@@ -842,7 +842,7 @@ impl<'a> Parser<'a> {
                 return self.parse_let(stmt_start, true);
             } else {
                 let expr = self.parse_block(stmt_start, NodeKind::ComptimeBlock);
-                self.finish_parse_stmt(stmt_start, expr);
+                return self.finish_parse_stmt(stmt_start, expr);
             }
         }
 

--- a/plankc/frontend/parser/src/parser/mod.rs
+++ b/plankc/frontend/parser/src/parser/mod.rs
@@ -858,7 +858,7 @@ impl<'a> Parser<'a> {
                 ParseExprMode::AllowAll,
                 OpPriority::ZERO,
             );
-            return self.finish_parse_stmt(stmt_start, expr);
+            return self.continue_parse_stmt(stmt_start, expr);
         }
 
         let Some(expr) = self.try_parse_expr(ParseExprMode::AllowAll) else {
@@ -868,10 +868,10 @@ impl<'a> Parser<'a> {
             return None;
         };
 
-        self.finish_parse_stmt(stmt_start, expr)
+        self.continue_parse_stmt(stmt_start, expr)
     }
 
-    fn finish_parse_stmt(&mut self, stmt_start: TokenIdx, expr: NodeIdx) -> Option<StmtResult> {
+    fn continue_parse_stmt(&mut self, stmt_start: TokenIdx, expr: NodeIdx) -> Option<StmtResult> {
         if self.eat(Token::Equals) {
             let mut assign = self.alloc_node_from(stmt_start, NodeKind::AssignStmt);
             self.push_child(&mut assign, expr);

--- a/plankc/frontend/parser/src/tests/errorless.rs
+++ b/plankc/frontend/parser/src/tests/errorless.rs
@@ -2258,7 +2258,7 @@ fn test_let_basic() {
                 "{"
                 StatementsList
                     " "
-                    LetStmt { mutable: false, typed: false }
+                    LetStmt { mutable: false, typed: false, comptime: false }
                         "let"
                         " "
                         Identifier
@@ -2289,7 +2289,7 @@ fn test_let_with_mut() {
                 "{"
                 StatementsList
                     " "
-                    LetStmt { mutable: true, typed: false }
+                    LetStmt { mutable: true, typed: false, comptime: false }
                         "let"
                         " "
                         "mut"
@@ -2322,7 +2322,7 @@ fn test_let_with_type() {
                 "{"
                 StatementsList
                     " "
-                    LetStmt { mutable: false, typed: true }
+                    LetStmt { mutable: false, typed: true, comptime: false }
                         "let"
                         " "
                         Identifier
@@ -2357,7 +2357,7 @@ fn test_let_full() {
                 "{"
                 StatementsList
                     " "
-                    LetStmt { mutable: true, typed: true }
+                    LetStmt { mutable: true, typed: true, comptime: false }
                         "let"
                         " "
                         "mut"
@@ -2383,6 +2383,79 @@ fn test_let_full() {
 // =============================================================================
 // Other Statements
 // =============================================================================
+
+#[test]
+fn test_comptime_block_stmt_member_access() {
+    assert_parses_to_cst_no_errors_dedented(
+        r#"
+        init { comptime { x }.foo; }
+        "#,
+        r#"
+        File
+            InitBlock
+                "init"
+                " "
+                "{"
+                StatementsList
+                    " "
+                    MemberExpr
+                        ComptimeBlock
+                            "comptime"
+                            " "
+                            "{"
+                            StatementsList
+                                " "
+                            Identifier
+                                "x"
+                            " "
+                            "}"
+                        "."
+                        Identifier
+                            "foo"
+                    ";"
+                    " "
+                "}"
+        "#,
+    );
+}
+
+#[test]
+fn test_comptime_block_stmt_infix() {
+    assert_parses_to_cst_no_errors_dedented(
+        r#"
+        init { comptime { x } + 2; }
+        "#,
+        r#"
+        File
+            InitBlock
+                "init"
+                " "
+                "{"
+                StatementsList
+                    " "
+                    BinaryExpr(Plus)
+                        ComptimeBlock
+                            "comptime"
+                            " "
+                            "{"
+                            StatementsList
+                                " "
+                            Identifier
+                                "x"
+                            " "
+                            "}"
+                        " "
+                        Operator
+                            "+"
+                        " "
+                        NumLiteral
+                            "2"
+                    ";"
+                    " "
+                "}"
+        "#,
+    );
+}
 
 #[test]
 fn test_return_stmt() {


### PR DESCRIPTION
Notable Changes:
* Existing AST and IR nodes are reused for `comptime let`.
* In parser, `comptime` keyword is now a two-way fork, necessitating some refactoring of parser code into continuation functions.
* HIR evaluator tracks extra scope-level state to handle evaluation:
  * Scope `Local` state tracks whether a binding is `comptime mut`.
  * Scope `comptime_assignability` tracks whether a `comptime mut` variable is assignable under a specific evaluation path depending on runtime/comptime determination.

Diagnostics:
* Comptime mut is redundant within comptime block
* Assignment to mutable comptime variable in implicit runtime context

AI Disclosure: I manually wrote the first pass end-to-end [implementation](https://github.com/plankevm/plank-monorepo/pull/252/commits/fa0dea78b2b7ca812f8ff31030880f2ec98515e6) without the use of AI, in order to learn about the internals of the frontend. I then used Claude to review and progressively refine my implementation.