### PR TITLE
Feat/add clz

### DIFF
--- a/plankc/crates/plank-evm/src/lib.rs
+++ b/plankc/crates/plank-evm/src/lib.rs
@@ -109,6 +109,10 @@ pub fn not(a: U256) -> U256 {
     !a
 }
 
+pub fn clz(a: U256) -> U256 {
+    U256::from(a.leading_zeros())
+}
+
 pub fn byte(i: U256, x: U256) -> U256 {
     let Ok(i) = usize::try_from(i) else {
         return U256::ZERO;

--- a/plankc/crates/plank-evm/src/tests.rs
+++ b/plankc/crates/plank-evm/src/tests.rs
@@ -249,6 +249,21 @@ fn test_not() {
 }
 
 #[test]
+fn test_clz() {
+    let cases = &[
+        uint!(0_U256),
+        uint!(1_U256),
+        uint!(255_U256),
+        uint!(256_U256),
+        uint!(1_U256) << 255,
+        (uint!(1_U256) << 160) - uint!(1_U256),
+        U256::MAX,
+        uint!(0xfedcba9812345678cafebabe00000000deadbeef_U256),
+    ];
+    assert_unop(opcode::CLZ, crate::clz, cases);
+}
+
+#[test]
 fn test_byte() {
     assert_binop(
         opcode::BYTE,

--- a/plankc/crates/plank-evm/src/version.rs
+++ b/plankc/crates/plank-evm/src/version.rs
@@ -20,6 +20,33 @@ pub enum EvmVersion {
     Osaka = 13,
 }
 
+impl EvmVersion {
+    pub fn name(self) -> &'static str {
+        match self {
+            EvmVersion::Homestead => "homestead",
+            EvmVersion::TangerineWhistle => "tangerineWhistle",
+            EvmVersion::SpuriousDragon => "spuriousDragon",
+            EvmVersion::Byzantium => "byzantium",
+            EvmVersion::Constantinople => "constantinople",
+            EvmVersion::Petersburg => "petersburg",
+            EvmVersion::Istanbul => "istanbul",
+            EvmVersion::Berlin => "berlin",
+            EvmVersion::London => "london",
+            EvmVersion::Paris => "paris",
+            EvmVersion::Shanghai => "shanghai",
+            EvmVersion::Cancun => "cancun",
+            EvmVersion::Prague => "prague",
+            EvmVersion::Osaka => "osaka",
+        }
+    }
+}
+
+impl std::fmt::Display for EvmVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 impl From<EvmVersion> for U256 {
     fn from(value: EvmVersion) -> Self {
         U256::from(value as u32)

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -23,6 +23,17 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         let args = &self.eval.hir.args[args];
         match builtin {
             Builtin::Runtime(runtime) => {
+                if let Some(required) = runtime_builtin_min_evm_version(runtime)
+                    && self.eval.evm_version < required
+                {
+                    self.diag_ctx.emit_builtin_requires_evm_version(
+                        runtime,
+                        self.eval.evm_version,
+                        required,
+                        self.loc(expr_span),
+                    );
+                    return Err(Poisoned);
+                }
                 if runtime.foldable() {
                     self.eval_runtime_foldable_builtin(runtime, args, expr_span)
                 } else {
@@ -47,18 +58,6 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr_span: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
-        if let Some(required) = runtime_builtin_min_evm_version(builtin)
-            && self.eval.evm_version < required
-        {
-            self.diag_ctx.emit_builtin_requires_evm_version(
-                builtin,
-                self.eval.evm_version,
-                required,
-                self.loc(expr_span),
-            );
-            return Err(Poisoned);
-        }
-
         let result_type = self.resolve_runtime_builtin_result_type(builtin, args, expr_span)?;
 
         let folded = self.with_values_buf(|this, values_buf_offset| {

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -1,5 +1,6 @@
 use crate::scope::{Diverge, EvalValue, LocalState, Scope};
 use alloy_primitives::U256;
+use plank_evm::EvmVersion;
 use plank_hir as hir;
 use plank_mir as mir;
 use plank_session::{
@@ -46,6 +47,18 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr_span: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
+        if let Some(required) = runtime_builtin_min_evm_version(builtin)
+            && self.eval.evm_version < required
+        {
+            self.diag_ctx.emit_builtin_requires_evm_version(
+                builtin,
+                self.eval.evm_version,
+                required,
+                self.loc(expr_span),
+            );
+            return Err(Poisoned);
+        }
+
         let result_type = self.resolve_runtime_builtin_result_type(builtin, args, expr_span)?;
 
         let folded = self.with_values_buf(|this, values_buf_offset| {
@@ -945,6 +958,13 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
     }
 }
 
+fn runtime_builtin_min_evm_version(builtin: RuntimeBuiltin) -> Option<EvmVersion> {
+    match builtin {
+        RuntimeBuiltin::Clz => Some(EvmVersion::Osaka),
+        _ => None,
+    }
+}
+
 pub(crate) fn fold_runtime_builtin(
     builtin: RuntimeBuiltin,
     args: &[ValueId],
@@ -957,6 +977,7 @@ pub(crate) fn fold_runtime_builtin(
             match builtin {
                 RuntimeBuiltin::IsZero => U256::from(plank_evm::iszero(a)),
                 RuntimeBuiltin::Not => plank_evm::not(a),
+                RuntimeBuiltin::Clz => plank_evm::clz(a),
                 _ => unreachable!("not a unary foldable builtin: {builtin}"),
             }
         }

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -645,14 +645,15 @@ impl DiagCtx<'_> {
         loc: SrcLoc,
     ) {
         Diagnostic::error(format!(
-            "builtin `{}` requires EVM version `{required:?}` or later",
+            "builtin `{}` requires EVM version `{required}` or later",
             builtin.name()
         ))
         .primary(
             loc.source,
             loc.span,
-            format!("not available in the active EVM version `{active:?}`"),
+            format!("not available in the active EVM version `{active}`"),
         )
+        .note(format!("recompile with `--evm-version {required}` or later"))
         .emit(self);
     }
 

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -637,6 +637,25 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
+    pub fn emit_builtin_requires_evm_version(
+        &mut self,
+        builtin: RuntimeBuiltin,
+        active: plank_evm::EvmVersion,
+        required: plank_evm::EvmVersion,
+        loc: SrcLoc,
+    ) {
+        Diagnostic::error(format!(
+            "builtin `{}` requires EVM version `{required:?}` or later",
+            builtin.name()
+        ))
+        .primary(
+            loc.source,
+            loc.span,
+            format!("not available in the active EVM version `{active:?}`"),
+        )
+        .emit(self);
+    }
+
     pub fn emit_custom_comptime_error(&mut self, message: impl Into<String>, loc: SrcLoc) {
         Diagnostic::error(message)
             .primary(loc.source, loc.span, "custom compile error triggered here")

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -169,6 +169,45 @@ fn test_comptime_active_evm_version_builtin() {
 }
 
 #[test]
+fn test_comptime_clz_builtin() {
+    assert_lowers_to(
+        r#"
+        const a = @evm_clz(1);
+        init {
+            let mut x: u256 = a;
+            @evm_stop();
+        }
+        "#,
+        r#"
+        ==== Functions ====
+        ; init
+        @fn0() -> never {
+            %0 : u256 = 255
+            %1 : never = @evm_stop()
+        }
+        "#,
+    );
+}
+
+#[test]
+fn test_clz_builtin_requires_osaka_version() {
+    assert_diagnostics_with_version(
+        r#"
+        const x = @evm_clz(1);
+        init { @evm_stop(); }
+        "#,
+        plank_evm::EvmVersion::Prague,
+        &[r#"
+        error: builtin `@evm_clz` requires EVM version `Osaka` or later
+         --> main.plk:1:11
+          |
+        1 | const x = @evm_clz(1);
+          |           ^^^^^^^^^^^ not available in the active EVM version `Prague`
+        "#],
+    );
+}
+
+#[test]
 fn test_comptime_unsupported_evm_builtin() {
     assert_diagnostics(
         r#"

--- a/plankc/frontend/hir-eval/src/tests/comptime.rs
+++ b/plankc/frontend/hir-eval/src/tests/comptime.rs
@@ -198,11 +198,13 @@ fn test_clz_builtin_requires_osaka_version() {
         "#,
         plank_evm::EvmVersion::Prague,
         &[r#"
-        error: builtin `@evm_clz` requires EVM version `Osaka` or later
+        error: builtin `@evm_clz` requires EVM version `osaka` or later
          --> main.plk:1:11
           |
         1 | const x = @evm_clz(1);
-          |           ^^^^^^^^^^^ not available in the active EVM version `Prague`
+          |           ^^^^^^^^^^^ not available in the active EVM version `prague`
+          |
+          = note: recompile with `--evm-version osaka` or later
         "#],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/mod.rs
+++ b/plankc/frontend/hir-eval/src/tests/mod.rs
@@ -19,15 +19,21 @@ fn std_project(source: &str) -> TestProject {
 }
 
 fn try_lower(project: impl Into<TestProject>) -> (Mir, ValueInterner, Session) {
+    try_lower_with_version(project, Default::default())
+}
+
+fn try_lower_with_version(
+    project: impl Into<TestProject>,
+    evm_version: plank_evm::EvmVersion,
+) -> (Mir, ValueInterner, Session) {
     let project = project.into();
     let mut session = Session::new();
     let project = project.build(&mut session);
-    let evm_spec_id = Default::default();
 
     let mut big_nums = ValueInterner::new();
     let hir = plank_hir::lower(&project, &mut big_nums, &mut session);
     let mir =
-        crate::evaluate(&hir, project.core_ops_source, &mut big_nums, &mut session, evm_spec_id);
+        crate::evaluate(&hir, project.core_ops_source, &mut big_nums, &mut session, evm_version);
 
     (mir, big_nums, session)
 }
@@ -51,6 +57,16 @@ fn assert_lowers_to(project: impl Into<TestProject>, expected: &str) {
 #[track_caller]
 fn assert_diagnostics(source: impl Into<TestProject>, expected: &[&str]) {
     assert_project_diagnostics(source, expected)
+}
+
+#[track_caller]
+fn assert_diagnostics_with_version(
+    source: impl Into<TestProject>,
+    evm_version: plank_evm::EvmVersion,
+    expected: &[&str],
+) {
+    let (_, _, session) = try_lower_with_version(source, evm_version);
+    plank_test_utils::assert_diagnostics(session.diagnostics(), &session, expected);
 }
 
 #[track_caller]

--- a/plankc/frontend/mir-lower-sona/src/function.rs
+++ b/plankc/frontend/mir-lower-sona/src/function.rs
@@ -443,6 +443,7 @@ impl<'a> FunctionLowerer<'a> {
             B::Shl => emit!(Shl::new, [a, b], Value),
             B::Shr => emit!(Shr::new, [a, b], Value),
             B::Sar => emit!(Sar::new, [a, b], Value),
+            B::Clz => emit!(EvmClz::new, [a], Value),
 
             B::Keccak256 => emit!(EvmKeccak256::new, [a, b], Value),
             B::Address => emit!(EvmAddress::new, [], Value),

--- a/plankc/frontend/mir-lower/src/builtins.rs
+++ b/plankc/frontend/mir-lower/src/builtins.rs
@@ -41,6 +41,7 @@ pub(crate) fn add_as_op(
         RuntimeBuiltin::Shl => OperationKind::Shl,
         RuntimeBuiltin::Shr => OperationKind::Shr,
         RuntimeBuiltin::Sar => OperationKind::Sar,
+        RuntimeBuiltin::Clz => OperationKind::Clz,
 
         // ========== EVM Keccak-256 ==========
         RuntimeBuiltin::Keccak256 => OperationKind::Keccak256,

--- a/plankc/frontend/session/src/builtins.rs
+++ b/plankc/frontend/session/src/builtins.rs
@@ -208,6 +208,7 @@ define_builtins! {
         SHL "@evm_shl" => Shl;
         SHR "@evm_shr" => Shr;
         SAR "@evm_sar" => Sar;
+        CLZ "@evm_clz" => Clz;
     }
 
     runtime_only_builtins {

--- a/plankc/frontend/values/src/builtins.rs
+++ b/plankc/frontend/values/src/builtins.rs
@@ -92,6 +92,7 @@ pub fn builtin_signatures(builtin: Builtin) -> &'static [BuiltinSignature] {
         B::Runtime(RB::Shl) => &[sig!([U256, U256 => U256])],
         B::Runtime(RB::Shr) => &[sig!([U256, U256 => U256])],
         B::Runtime(RB::Sar) => &[sig!([U256, U256 => U256])],
+        B::Runtime(RB::Clz) => &[sig!([U256 => U256])],
 
         // Runtime only
         B::Runtime(RB::Keccak256) => &[sig!([MP, U256 => U256])],

--- a/plankc/justfile
+++ b/plankc/justfile
@@ -33,23 +33,23 @@ test-plank-diff: test-plank-diff-sir test-plank-diff-sona
 
 [working-directory: 'plank-diff-tests/']
 test-plank-diff-sir: build-debug
-     PLANK_BACKEND=sir-debug   PLANK_OPTIMIZE=     forge test --nmp test/benchmark/*
-     PLANK_BACKEND=sir-debug   PLANK_OPTIMIZE=csud forge test --nmp test/benchmark/*
-     PLANK_BACKEND=sir-release PLANK_OPTIMIZE=     forge test --nmp test/benchmark/*
-     PLANK_BACKEND=sir-release PLANK_OPTIMIZE=csud forge test --nmp test/benchmark/*
+     PLANK_BACKEND=sir-debug   PLANK_OPTIMIZE=     forge test --nmp 'test/benchmark/*'
+     PLANK_BACKEND=sir-debug   PLANK_OPTIMIZE=csud forge test --nmp 'test/benchmark/*'
+     PLANK_BACKEND=sir-release PLANK_OPTIMIZE=     forge test --nmp 'test/benchmark/*'
+     PLANK_BACKEND=sir-release PLANK_OPTIMIZE=csud forge test --nmp 'test/benchmark/*'
 
 [working-directory: 'plank-diff-tests/']
 test-plank-diff-sona: build-debug
-     PLANK_BACKEND=sona PLANK_OPTIMIZE=   forge test --nmp test/benchmark/*
-     PLANK_BACKEND=sona PLANK_OPTIMIZE=O1 forge test --nmp test/benchmark/*
+     PLANK_BACKEND=sona PLANK_OPTIMIZE=   forge test --nmp 'test/benchmark/*'
+     PLANK_BACKEND=sona PLANK_OPTIMIZE=O1 forge test --nmp 'test/benchmark/*'
 
 [working-directory: 'plank-diff-tests/']
 bytecode-bench-check: build-debug
-    forge test --mp test/benchmark/* --gas-snapshot-check true
+    forge test --mp 'test/benchmark/*' --gas-snapshot-check true
 
 [working-directory: 'plank-diff-tests/']
 bytecode-bench-update: build-debug
-    forge test --mp test/benchmark/*
+    forge test --mp 'test/benchmark/*'
 
 test-all: test test-sir-diff test-plank-diff bytecode-bench-check
 

--- a/plankc/plank-diff-tests/foundry.toml
+++ b/plankc/plank-diff-tests/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 ffi = true
+evm_version = "osaka"
 
 optimizer_runs = 1000000
 bytecode_hash = "none"

--- a/plankc/plank-diff-tests/snapshots/bit.json
+++ b/plankc/plank-diff-tests/snapshots/bit.json
@@ -1,0 +1,4 @@
+{
+  "clz.fallback": "23142",
+  "clz.native": "22191"
+}

--- a/plankc/plank-diff-tests/src/std/Bit.sol
+++ b/plankc/plank-diff-tests/src/std/Bit.sol
@@ -11,7 +11,6 @@ contract Bit {
         }
     }
 
-    // Obvious-by-construction reference for count-leading-zeros.
     function clz(uint256 x) internal pure returns (uint256) {
         if (x == 0) return 256;
         uint256 r = 0;

--- a/plankc/plank-diff-tests/src/std/Bit.sol
+++ b/plankc/plank-diff-tests/src/std/Bit.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.30;
+
+contract Bit {
+    fallback() external payable {
+        uint256 x = abi.decode(msg.data, (uint256));
+        uint256 r = clz(x);
+        bytes memory out = abi.encode(r);
+        assembly ("memory-safe") {
+            return(add(out, 0x20), mload(out))
+        }
+    }
+
+    // Obvious-by-construction reference for count-leading-zeros.
+    function clz(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 256;
+        uint256 r = 0;
+        while (x & (uint256(1) << 255) == 0) {
+            x <<= 1;
+            r++;
+        }
+        return r;
+    }
+}

--- a/plankc/plank-diff-tests/src/std/bit_test.plk
+++ b/plankc/plank-diff-tests/src/std/bit_test.plk
@@ -1,0 +1,13 @@
+import std::abi::{abi_encode, abi_decode};
+import std::membytes::membytes_from_ptr;
+import std::bit::clz;
+
+init {
+    let size = @evm_calldatasize();
+    let ptr = @malloc_zeroed(size);
+    @evm_calldatacopy(ptr, 0, size);
+    let input = membytes_from_ptr(ptr, size);
+    let x = abi_decode(u256, input);
+    let encoded = abi_encode(clz(x));
+    @evm_return(encoded.ptr, encoded.length);
+}

--- a/plankc/plank-diff-tests/test/benchmark/Bit.b.sol
+++ b/plankc/plank-diff-tests/test/benchmark/Bit.b.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "test/BaseTest.sol";
+
+abstract contract ClzBenchmarkBase is BaseTest {
+    address impl;
+
+    function group() internal pure returns (string memory) {
+        return "bit";
+    }
+
+    function key() internal pure virtual returns (string memory);
+    function compile() internal virtual returns (bytes memory);
+
+    function setUp() public {
+        impl = makeAddr("clz-bench-impl");
+        vm.etch(impl, compile());
+    }
+
+    function test_clz() public {
+        (bool ok,) = impl.call(abi.encode(uint256(1) << 127));
+        vm.snapshotGasLastCall(group(), key());
+        assertTrue(ok, "clz call reverted");
+    }
+}
+
+/// forge-config: default.isolate = true
+contract ClzFallback is ClzBenchmarkBase {
+    function key() internal pure override returns (string memory) {
+        return "clz.fallback";
+    }
+
+    function compile() internal override returns (bytes memory) {
+        return plankBuild(
+            "src/std/bit_test.plk",
+            baseBuildOptions().withBackend("sir-release").withOptimizations("csud").withEvmVersion("prague")
+        );
+    }
+}
+
+/// forge-config: default.isolate = true
+contract ClzNative is ClzBenchmarkBase {
+    function key() internal pure override returns (string memory) {
+        return "clz.native";
+    }
+
+    function compile() internal override returns (bytes memory) {
+        return plankBuild(
+            "src/std/bit_test.plk",
+            baseBuildOptions().withBackend("sir-release").withOptimizations("csud").withEvmVersion("osaka")
+        );
+    }
+}

--- a/plankc/plank-diff-tests/test/std/Bit.t.sol
+++ b/plankc/plank-diff-tests/test/std/Bit.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "../BaseTest.sol";
+import {Bit} from "src/std/Bit.sol";
+
+contract BitTest is BaseTest {
+    Bit solRef = new Bit();
+
+    // Compiled with a pre-Osaka EVM version that lacks the CLZ opcode: exercises
+    // the portable fallback in `std::bit::clz`.
+    address plankFallback = makeAddr("plank-clz-fallback");
+
+    function setUp() public {
+        vm.etch(plankFallback, plank("src/std/bit_test.plk", "prague"));
+    }
+
+    function _clz(address impl, uint256 x) internal returns (uint256) {
+        (bool ok, bytes memory out) = impl.call(abi.encode(x));
+        assertTrue(ok, "call reverted");
+        return abi.decode(out, (uint256));
+    }
+
+    function test_clz_knownValues() public {
+        assertEq(_clz(plankFallback, 0), 256);
+        assertEq(_clz(plankFallback, 1), 255);
+        assertEq(_clz(plankFallback, 255), 248);
+        assertEq(_clz(plankFallback, 256), 247);
+        assertEq(_clz(plankFallback, 1 << 255), 0);
+        assertEq(_clz(plankFallback, (1 << 160) - 1), 96);
+        assertEq(_clz(plankFallback, type(uint256).max), 0);
+    }
+
+    function test_fuzzing_clzFallbackMatchesReference(uint256 x) public {
+        (, bytes memory refOut) = address(solRef).call(abi.encode(x));
+        assertEq(_clz(plankFallback, x), abi.decode(refOut, (uint256)));
+    }
+
+    // On Osaka (the default) the opcode path emits CLZ (0x1e, EIP-7939). We assert
+    // the byte is present in the compiled output rather than executing it, since
+    // the test EVM may not enable the opcode yet.
+    function test_osakaCompilesToClzOpcode() public {
+        bytes memory code = plank("src/std/bit_test.plk", "osaka");
+        bool found;
+        for (uint256 i = 0; i < code.length; i++) {
+            if (uint8(code[i]) == 0x1e) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "CLZ opcode not emitted on Osaka EVM version");
+    }
+}

--- a/plankc/plank-diff-tests/test/std/Bit.t.sol
+++ b/plankc/plank-diff-tests/test/std/Bit.t.sol
@@ -7,12 +7,12 @@ import {Bit} from "src/std/Bit.sol";
 contract BitTest is BaseTest {
     Bit solRef = new Bit();
 
-    // Compiled with a pre-Osaka EVM version that lacks the CLZ opcode: exercises
-    // the portable fallback in `std::bit::clz`.
     address plankFallback = makeAddr("plank-clz-fallback");
+    address plankOsaka = makeAddr("plank-clz-osaka");
 
     function setUp() public {
         vm.etch(plankFallback, plank("src/std/bit_test.plk", "prague"));
+        vm.etch(plankOsaka, plank("src/std/bit_test.plk", "osaka"));
     }
 
     function _clz(address impl, uint256 x) internal returns (uint256) {
@@ -21,24 +21,36 @@ contract BitTest is BaseTest {
         return abi.decode(out, (uint256));
     }
 
-    function test_clz_knownValues() public {
-        assertEq(_clz(plankFallback, 0), 256);
-        assertEq(_clz(plankFallback, 1), 255);
-        assertEq(_clz(plankFallback, 255), 248);
-        assertEq(_clz(plankFallback, 256), 247);
-        assertEq(_clz(plankFallback, 1 << 255), 0);
-        assertEq(_clz(plankFallback, (1 << 160) - 1), 96);
-        assertEq(_clz(plankFallback, type(uint256).max), 0);
+    function _assertKnownValues(address impl) internal {
+        assertEq(_clz(impl, 0), 256);
+        assertEq(_clz(impl, 1), 255);
+        assertEq(_clz(impl, 255), 248);
+        assertEq(_clz(impl, 256), 247);
+        assertEq(_clz(impl, 1 << 255), 0);
+        assertEq(_clz(impl, (1 << 160) - 1), 96);
+        assertEq(_clz(impl, type(uint256).max), 0);
+    }
+
+    function test_clz_knownValues_fallback() public {
+        _assertKnownValues(plankFallback);
+    }
+
+    function test_clz_knownValues_osaka() public {
+        _assertKnownValues(plankOsaka);
     }
 
     function test_fuzzing_clzFallbackMatchesReference(uint256 x) public {
-        (, bytes memory refOut) = address(solRef).call(abi.encode(x));
+        (bool ok, bytes memory refOut) = address(solRef).call(abi.encode(x));
+        assertTrue(ok, "ref call reverted");
         assertEq(_clz(plankFallback, x), abi.decode(refOut, (uint256)));
     }
 
-    // On Osaka (the default) the opcode path emits CLZ (0x1e, EIP-7939). We assert
-    // the byte is present in the compiled output rather than executing it, since
-    // the test EVM may not enable the opcode yet.
+    function test_fuzzing_clzOsakaMatchesReference(uint256 x) public {
+        (bool ok, bytes memory refOut) = address(solRef).call(abi.encode(x));
+        assertTrue(ok, "ref call reverted");
+        assertEq(_clz(plankOsaka, x), abi.decode(refOut, (uint256)));
+    }
+
     function test_osakaCompilesToClzOpcode() public {
         bytes memory code = plank("src/std/bit_test.plk", "osaka");
         bool found;

--- a/plankc/plank-diff-tests/test/std/Bit.t.sol
+++ b/plankc/plank-diff-tests/test/std/Bit.t.sol
@@ -50,16 +50,4 @@ contract BitTest is BaseTest {
         assertTrue(ok, "ref call reverted");
         assertEq(_clz(plankOsaka, x), abi.decode(refOut, (uint256)));
     }
-
-    function test_osakaCompilesToClzOpcode() public {
-        bytes memory code = plank("src/std/bit_test.plk", "osaka");
-        bool found;
-        for (uint256 i = 0; i < code.length; i++) {
-            if (uint8(code[i]) == 0x1e) {
-                found = true;
-                break;
-            }
-        }
-        assertTrue(found, "CLZ opcode not emitted on Osaka EVM version");
-    }
 }

--- a/plankc/sir/crates/assembler/src/op.rs
+++ b/plankc/sir/crates/assembler/src/op.rs
@@ -26,6 +26,7 @@ pub const BYTE: u8 = 0x1A;
 pub const SHL: u8 = 0x1B;
 pub const SHR: u8 = 0x1C;
 pub const SAR: u8 = 0x1D;
+pub const CLZ: u8 = 0x1E;
 // Keccak 0x20
 pub const KECCAK256: u8 = 0x20;
 // Call context introspection 0x30 - 0x3f
@@ -187,6 +188,7 @@ pub fn name(opcode: u8) -> &'static str {
         SHL => "SHL",
         SHR => "SHR",
         SAR => "SAR",
+        CLZ => "CLZ",
         KECCAK256 => "KECCAK256",
         ADDRESS => "ADDRESS",
         BALANCE => "BALANCE",

--- a/plankc/sir/crates/data/src/operation/effects.rs
+++ b/plankc/sir/crates/data/src/operation/effects.rs
@@ -91,7 +91,8 @@ impl Effect {
             | OperationKind::Byte
             | OperationKind::Shl
             | OperationKind::Shr
-            | OperationKind::Sar => Effect::PURE,
+            | OperationKind::Sar
+            | OperationKind::Clz => Effect::PURE,
 
             OperationKind::Keccak256 => Effect::MEMORY_READ,
 

--- a/plankc/sir/crates/data/src/operation/mod.rs
+++ b/plankc/sir/crates/data/src/operation/mod.rs
@@ -148,6 +148,7 @@ impl OperationKind {
             OperationKind::Shl => op::SHL,
             OperationKind::Shr => op::SHR,
             OperationKind::Sar => op::SAR,
+            OperationKind::Clz => op::CLZ,
 
             // ========== EVM Keccak-256 ==========
             OperationKind::Keccak256 => op::KECCAK256,
@@ -251,6 +252,7 @@ define_operations! {
     Shl(InlineOperands<2, 1>) "shl",
     Shr(InlineOperands<2, 1>) "shr",
     Sar(InlineOperands<2, 1>) "sar",
+    Clz(InlineOperands<1, 1>) "clz",
 
     // ========== EVM Keccak-256 ==========
     Keccak256(InlineOperands<2, 1>) "keccak256",
@@ -380,6 +382,7 @@ impl OperationKind {
             | OperationKind::Shl
             | OperationKind::Shr
             | OperationKind::Sar
+            | OperationKind::Clz
             | OperationKind::Keccak256
             | OperationKind::Address
             | OperationKind::Balance

--- a/plankc/sir/crates/passes/src/analyses/allocation_liveness.rs
+++ b/plankc/sir/crates/passes/src/analyses/allocation_liveness.rs
@@ -132,6 +132,7 @@ fn operation_causes_ptr_escape(program: &EthIRProgram, op: Operation, local: Loc
         | Operation::Shl(_)
         | Operation::Shr(_)
         | Operation::Sar(_)
+        | Operation::Clz(_)
         | Operation::Address(_)
         | Operation::Origin(_)
         | Operation::Caller(_)

--- a/plankc/sir/crates/stack-scheduling/src/op_model.rs
+++ b/plankc/sir/crates/stack-scheduling/src/op_model.rs
@@ -28,6 +28,7 @@ pub fn is_flippable(op: OperationKind) -> bool {
         | OperationKind::Shl
         | OperationKind::Shr
         | OperationKind::Sar
+        | OperationKind::Clz
         | OperationKind::Keccak256
         | OperationKind::Address
         | OperationKind::Balance

--- a/std/bit.plk
+++ b/std/bit.plk
@@ -16,12 +16,12 @@ const clz = fn (x: u256) u256 {
 // Recreated from solady `LibBit.clz` (MIT License), Copyright (c) 2022 solady:
 // https://github.com/Vectorized/solady/blob/5dc5fc87374e6e9de15e8139c09d80fde5a22303/src/utils/LibBit.sol#L33-L45
 const clz_fallback = fn (x: u256) u256 {
-    let r0 = @evm_shl(7, bool_to_u256(@evm_lt(0xffffffffffffffffffffffffffffffff, x)));
-    let r1 = @evm_or(r0, @evm_shl(6, bool_to_u256(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x)))));
-    let r2 = @evm_or(r1, @evm_shl(5, bool_to_u256(@evm_lt(0xffffffff, @evm_shr(r1, x)))));
-    let r3 = @evm_or(r2, @evm_shl(4, bool_to_u256(@evm_lt(0xffff, @evm_shr(r2, x)))));
-    let r4 = @evm_or(r3, @evm_shl(3, bool_to_u256(@evm_lt(0xff, @evm_shr(r3, x)))));
-    let index = @evm_and(0x1f, @evm_shr(@evm_shr(r4, x), 0x8421084210842108cc6318c6db6d54be));
+    let r0 = bool_to_u256(0xffffffffffffffffffffffffffffffff < x) << 7;
+    let r1 = r0 | (bool_to_u256(0xffffffffffffffff < (x >> r0)) << 6);
+    let r2 = r1 | (bool_to_u256(0xffffffff < (x >> r1)) << 5);
+    let r3 = r2 | (bool_to_u256(0xffff < (x >> r2)) << 4);
+    let r4 = r3 | (bool_to_u256(0xff < (x >> r3)) << 3);
+    let index = 0x1f & (0x8421084210842108cc6318c6db6d54be >> (x >> r4));
     let table = 0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff;
-    @evm_add(@evm_xor(r4, @evm_byte(index, table)), bool_to_u256(@evm_iszero(x)))
+    (r4 ^ @evm_byte(index, table)) +% bool_to_u256(@evm_iszero(x))
 };

--- a/std/bit.plk
+++ b/std/bit.plk
@@ -1,0 +1,46 @@
+import std::version::{active_evm_version, OSAKA};
+
+// Whether the active EVM version supports the `CLZ` opcode (EIP-7939, shipped in
+// Osaka). Bound as a `const` so the branch in `clz` sees a comptime condition and
+// prunes the unused path — otherwise `@evm_clz` would be lowered (and rejected) on
+// versions that lack the opcode.
+const HAS_CLZ_OPCODE = active_evm_version().id >= OSAKA.id;
+
+// Count leading zeros: the number of zero bits preceding the most significant
+// set bit of `x`. Returns 256 when `x` is zero.
+//
+// On EVM versions that support the `CLZ` opcode (EIP-7939) this uses the native
+// opcode; otherwise it falls back to a portable implementation. The branch is
+// selected at compile time, so only one path is ever emitted.
+const clz = fn (x: u256) u256 {
+    if HAS_CLZ_OPCODE {
+        @evm_clz(x)
+    } else {
+        clz_fallback(x)
+    }
+};
+
+// `word` when `cond` holds, otherwise zero. Used to turn the boolean comparison
+// builtins into the 0/word selectors the count-leading-zeros search needs.
+const select = fn (cond: bool, word: u256) u256 {
+    if cond {
+        word
+    } else {
+        0
+    }
+};
+
+// Count leading zeros for EVM versions without the `CLZ` opcode.
+//
+// Recreated from solady `LibBit.clz` (MIT License), Copyright (c) 2022 solady:
+// https://github.com/Vectorized/solady/blob/5dc5fc87374e6e9de15e8139c09d80fde5a22303/src/utils/LibBit.sol#L33-L45
+const clz_fallback = fn (x: u256) u256 {
+    let r0 = select(@evm_lt(0xffffffffffffffffffffffffffffffff, x), 128);
+    let r1 = @evm_or(r0, select(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x)), 64));
+    let r2 = @evm_or(r1, select(@evm_lt(0xffffffff, @evm_shr(r1, x)), 32));
+    let r3 = @evm_or(r2, select(@evm_lt(0xffff, @evm_shr(r2, x)), 16));
+    let r4 = @evm_or(r3, select(@evm_lt(0xff, @evm_shr(r3, x)), 8));
+    let index = @evm_and(0x1f, @evm_shr(@evm_shr(r4, x), 0x8421084210842108cc6318c6db6d54be));
+    let table = 0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff;
+    @evm_add(@evm_xor(r4, @evm_byte(index, table)), select(@evm_iszero(x), 1))
+};

--- a/std/bit.plk
+++ b/std/bit.plk
@@ -1,17 +1,8 @@
 import std::version::{active_evm_version, OSAKA};
+import std::core_ops::{bool_to_u256};
 
-// Whether the active EVM version supports the `CLZ` opcode (EIP-7939, shipped in
-// Osaka). Bound as a `const` so the branch in `clz` sees a comptime condition and
-// prunes the unused path — otherwise `@evm_clz` would be lowered (and rejected) on
-// versions that lack the opcode.
 const HAS_CLZ_OPCODE = active_evm_version().id >= OSAKA.id;
 
-// Count leading zeros: the number of zero bits preceding the most significant
-// set bit of `x`. Returns 256 when `x` is zero.
-//
-// On EVM versions that support the `CLZ` opcode (EIP-7939) this uses the native
-// opcode; otherwise it falls back to a portable implementation. The branch is
-// selected at compile time, so only one path is ever emitted.
 const clz = fn (x: u256) u256 {
     if HAS_CLZ_OPCODE {
         @evm_clz(x)
@@ -20,27 +11,17 @@ const clz = fn (x: u256) u256 {
     }
 };
 
-// `word` when `cond` holds, otherwise zero. Used to turn the boolean comparison
-// builtins into the 0/word selectors the count-leading-zeros search needs.
-const select = fn (cond: bool, word: u256) u256 {
-    if cond {
-        word
-    } else {
-        0
-    }
-};
-
 // Count leading zeros for EVM versions without the `CLZ` opcode.
 //
 // Recreated from solady `LibBit.clz` (MIT License), Copyright (c) 2022 solady:
 // https://github.com/Vectorized/solady/blob/5dc5fc87374e6e9de15e8139c09d80fde5a22303/src/utils/LibBit.sol#L33-L45
 const clz_fallback = fn (x: u256) u256 {
-    let r0 = select(@evm_lt(0xffffffffffffffffffffffffffffffff, x), 128);
-    let r1 = @evm_or(r0, select(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x)), 64));
-    let r2 = @evm_or(r1, select(@evm_lt(0xffffffff, @evm_shr(r1, x)), 32));
-    let r3 = @evm_or(r2, select(@evm_lt(0xffff, @evm_shr(r2, x)), 16));
-    let r4 = @evm_or(r3, select(@evm_lt(0xff, @evm_shr(r3, x)), 8));
+    let r0 = bool_to_u256(@evm_lt(0xffffffffffffffffffffffffffffffff, x)) *% 128;
+    let r1 = @evm_or(r0, bool_to_u256(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x))) *% 64);
+    let r2 = @evm_or(r1, bool_to_u256(@evm_lt(0xffffffff, @evm_shr(r1, x))) *% 32);
+    let r3 = @evm_or(r2, bool_to_u256(@evm_lt(0xffff, @evm_shr(r2, x))) *% 16);
+    let r4 = @evm_or(r3, bool_to_u256(@evm_lt(0xff, @evm_shr(r3, x))) *% 8);
     let index = @evm_and(0x1f, @evm_shr(@evm_shr(r4, x), 0x8421084210842108cc6318c6db6d54be));
     let table = 0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff;
-    @evm_add(@evm_xor(r4, @evm_byte(index, table)), select(@evm_iszero(x), 1))
+    @evm_add(@evm_xor(r4, @evm_byte(index, table)), bool_to_u256(@evm_iszero(x)))
 };

--- a/std/bit.plk
+++ b/std/bit.plk
@@ -16,11 +16,11 @@ const clz = fn (x: u256) u256 {
 // Recreated from solady `LibBit.clz` (MIT License), Copyright (c) 2022 solady:
 // https://github.com/Vectorized/solady/blob/5dc5fc87374e6e9de15e8139c09d80fde5a22303/src/utils/LibBit.sol#L33-L45
 const clz_fallback = fn (x: u256) u256 {
-    let r0 = bool_to_u256(@evm_lt(0xffffffffffffffffffffffffffffffff, x)) *% 128;
-    let r1 = @evm_or(r0, bool_to_u256(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x))) *% 64);
-    let r2 = @evm_or(r1, bool_to_u256(@evm_lt(0xffffffff, @evm_shr(r1, x))) *% 32);
-    let r3 = @evm_or(r2, bool_to_u256(@evm_lt(0xffff, @evm_shr(r2, x))) *% 16);
-    let r4 = @evm_or(r3, bool_to_u256(@evm_lt(0xff, @evm_shr(r3, x))) *% 8);
+    let r0 = @evm_shl(7, bool_to_u256(@evm_lt(0xffffffffffffffffffffffffffffffff, x)));
+    let r1 = @evm_or(r0, @evm_shl(6, bool_to_u256(@evm_lt(0xffffffffffffffff, @evm_shr(r0, x)))));
+    let r2 = @evm_or(r1, @evm_shl(5, bool_to_u256(@evm_lt(0xffffffff, @evm_shr(r1, x)))));
+    let r3 = @evm_or(r2, @evm_shl(4, bool_to_u256(@evm_lt(0xffff, @evm_shr(r2, x)))));
+    let r4 = @evm_or(r3, @evm_shl(3, bool_to_u256(@evm_lt(0xff, @evm_shr(r3, x)))));
     let index = @evm_and(0x1f, @evm_shr(@evm_shr(r4, x), 0x8421084210842108cc6318c6db6d54be));
     let table = 0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff;
     @evm_add(@evm_xor(r4, @evm_byte(index, table)), bool_to_u256(@evm_iszero(x)))


### PR DESCRIPTION
Closes #209

### Summary

Adds [`CLZ`](https://eips.ethereum.org/EIPS/eip-7939) (count-leading-zeros, EIP-7939) end to end: the comptime-foldable `@evm_clz` builtin, version-agnostic `CLZ` support in SIR, and a `std::bit::clz` that picks between the native opcode and a portable fallback at compile time based on the active EVM version.

The interesting part wasn't the opcode — it was making "use the opcode when the target supports it, fall back otherwise" resolve entirely at comptime, with a hard error if anyone reaches for `@evm_clz` directly on a target that can't run it. A couple of decisions there are worth a careful look.

### Decisions this opened up

1. **SIR stays version-agnostic.** `CLZ` is added to SIR purely as opcode `0x1E` — a pure, single-input/single-output op (`effects.rs` → `PURE`, `op_model` → flippable, liveness → no ptr escape). The backend knows nothing about *when* `CLZ` is legal; all version policy lives in the frontend. This keeps SIR a dumb lowering target and matches how the other shift ops (`SHL`/`SHR`/`SAR`) are modeled.

2. **Version gating is two layers, and they do different jobs.**
   - **Hard guard (frontend builtin):** `@evm_clz` carries a minimum EVM version. `runtime_builtin_min_evm_version(Clz) => Osaka` in `hir-eval/src/builtins.rs` is checked at the top of `build_runtime_builtin`; below the required version it emits `emit_builtin_requires_evm_version` and poisons. So *any* direct use of `@evm_clz` on a pre-Osaka target is a compile error, not silently-wrong codegen. The mechanism is generic — future version-gated builtins just add a match arm.
   - **Soft dispatch (stdlib):** `std::bit::clz` branches on `HAS_CLZ_OPCODE` and lowers only the arm that's valid for the target.

3. **The stdlib condition *must* be a `const`, and that's load-bearing.** `const HAS_CLZ_OPCODE = active_evm_version().id >= OSAKA.id;` is a comptime constant, so the `if` is folded and the dead arm is **pruned before lowering**. If the condition were an inline call instead of a `const`, both arms would lower, the `@evm_clz` arm would hit the hard guard from (2), and the *fallback* path would fail to compile on pre-Osaka — exactly the targets it exists to serve. The two layers only coexist because the prune happens first.

4. **Fallback is a recreation of solady `LibBit.clz`** (MIT, credited in `std/bit.plk`), adapted to Plank: `bool_to_u256(@evm_lt(..)) *% 2^k` in place of solady's `shl(k, lt(..))`, then the de Bruijn index + byte-table lookup, `+ iszero(x)` so `clz(0) == 256`.

### Please scrutinize

- **`std/bit.plk` correctness.** The fallback is a hand-port of a bit-twiddling routine — the de Bruijn multiplier `0x8421...54be`, the lookup `table`, and the `*%`-for-`shl` substitution are all transcription-sensitive. The diff tests fuzz both the fallback (`prague`) and opcode (`osaka`) builds against a naive Solidity reference (`Bit.sol`) and assert the `0x1E` byte is actually emitted on Osaka, but a second human read of the constants vs. the cited solady revision is worth it.
- **How min EVM version is checked.** See decision (2)+(3): the hard guard in `build_runtime_builtin` plus the comptime-const prune in `clz`. The thing to verify is that the guard fires for *direct* `@evm_clz` misuse while the stdlib `clz` never trips it on the fallback path — covered by `test_clz_builtin_requires_osaka_version` and the dual `prague`/`osaka` diff tests.

### AI disclosure

Per [CONTRIBUTING.md](../../CONTRIBUTING.md), disclosing AI use: I used AI **only to navigate the codebase and generate this PR message**. Even so, this genuinely needs a careful human review.
