### PR TITLE
Implement `@compile_log` builtin

### DIFF
--- a/plankc/frontend/driver/src/lib.rs
+++ b/plankc/frontend/driver/src/lib.rs
@@ -59,8 +59,11 @@ impl<'a, F: SourceFs> Driver<'a, F> {
         for diagnostic in self.session.diagnostics() {
             anstream::eprintln!("{}\n", diagnostic.render_styled(&self.session));
         }
-        for compile_log in self.session.compile_logs() {
-            anstream::eprintln!("{}", compile_log.format(&self.session));
+        if self.session.has_compile_logs() {
+            anstream::eprintln!("Compile Log Output:");
+            for compile_log in self.session.compile_logs() {
+                anstream::eprintln!("{}", compile_log.format());
+            }
         }
         std::process::exit(1)
     }

--- a/plankc/frontend/driver/src/lib.rs
+++ b/plankc/frontend/driver/src/lib.rs
@@ -62,7 +62,7 @@ impl<'a, F: SourceFs> Driver<'a, F> {
         if self.session.has_compile_logs() {
             anstream::eprintln!("Compile Log Output:");
             for compile_log in self.session.compile_logs() {
-                anstream::eprintln!("{}", compile_log.format());
+                anstream::eprintln!("{compile_log}");
             }
         }
         std::process::exit(1)

--- a/plankc/frontend/driver/src/lib.rs
+++ b/plankc/frontend/driver/src/lib.rs
@@ -59,6 +59,9 @@ impl<'a, F: SourceFs> Driver<'a, F> {
         for diagnostic in self.session.diagnostics() {
             anstream::eprintln!("{}\n", diagnostic.render_styled(&self.session));
         }
+        for compile_log in self.session.compile_logs() {
+            anstream::eprintln!("{}", compile_log.format(&self.session));
+        }
         std::process::exit(1)
     }
 

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -671,7 +671,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         };
 
         self.diag_ctx.emit_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
-        return Ok(Ok(EvalValue::Comptime(ValueId::VOID)));
+        Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
     }
 
     /// Emits MIR instructions for a runtime uninit value (memptr or struct containing memptr).

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -670,7 +670,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             return Err(Poisoned);
         };
 
-        self.diag_ctx.emit_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
+        self.diag_ctx.record_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
         Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
     }
 

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -4,7 +4,7 @@ use plank_hir as hir;
 use plank_mir as mir;
 use plank_session::{
     Builtin, BytesId, CBytes, MaybePoisoned, Poisoned, RuntimeBuiltin, SourceSpan, SrcLoc,
-    builtins::{Arity, BuiltinKind},
+    builtins::BuiltinKind,
 };
 use plank_values::{
     Compound, PrimitiveType, StructView, Type, TypeFlags, TypeId, TypeInterner, TypeName, Value,
@@ -386,12 +386,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
-        let BuiltinKind::ComptimeDynamic { arity } = builtin.kind() else {
-            unreachable!("not a comptime dynamic builtin: {builtin}")
-        };
-        if let Arity::Exact(expected) = arity
-            && expected != args.len()
-        {
+        if builtin_sigs::arg_count(builtin) != args.len() {
             self.diag_ctx.emit_wrong_arg_count(
                 self.eval.values,
                 builtin,
@@ -667,23 +662,16 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr_span: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
-        let expr_loc = self.loc(expr_span);
-        self.with_values_buf(|this, offset| {
-            for &arg in args {
-                let (state, _, origin) = this.bindings[arg].poisoned()?;
-                let LocalState::Comptime(vid) = state else {
-                    this.diag_ctx.emit_runtime_ref_in_comptime(expr_loc, this.origin_loc(origin));
-                    return Err(Poisoned);
-                };
-                this.values_buf.push(vid);
-            }
-            this.diag_ctx.record_compile_log(
-                this.eval.values,
-                &this.eval.values_buf[offset..],
-                expr_loc,
-            );
-            Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
-        })
+        let &[obj] = args else { unreachable!("arg count checked") };
+        let (state, _, origin) = self.bindings[obj].poisoned()?;
+        let LocalState::Comptime(obj_vid) = state else {
+            self.diag_ctx
+                .emit_runtime_ref_in_comptime(self.loc(expr_span), self.origin_loc(origin));
+            return Err(Poisoned);
+        };
+
+        self.diag_ctx.record_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
+        Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
     }
 
     /// Emits MIR instructions for a runtime uninit value (memptr or struct containing memptr).

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -4,7 +4,7 @@ use plank_hir as hir;
 use plank_mir as mir;
 use plank_session::{
     Builtin, BytesId, CBytes, MaybePoisoned, Poisoned, RuntimeBuiltin, SourceSpan, SrcLoc,
-    builtins::BuiltinKind,
+    builtins::{Arity, BuiltinKind},
 };
 use plank_values::{
     Compound, PrimitiveType, StructView, Type, TypeFlags, TypeId, TypeInterner, TypeName, Value,
@@ -386,7 +386,12 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
-        if builtin_sigs::arg_count(builtin) != args.len() {
+        let BuiltinKind::ComptimeDynamic { arity } = builtin.kind() else {
+            unreachable!("not a comptime dynamic builtin: {builtin}")
+        };
+        if let Arity::Exact(expected) = arity
+            && expected != args.len()
+        {
             self.diag_ctx.emit_wrong_arg_count(
                 self.eval.values,
                 builtin,
@@ -662,16 +667,23 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         args: &[hir::LocalId],
         expr_span: SourceSpan,
     ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
-        let &[obj] = args else { unreachable!("arg count checked") };
-        let (state, _, origin) = self.bindings[obj].poisoned()?;
-        let LocalState::Comptime(obj_vid) = state else {
-            self.diag_ctx
-                .emit_runtime_ref_in_comptime(self.loc(expr_span), self.origin_loc(origin));
-            return Err(Poisoned);
-        };
-
-        self.diag_ctx.record_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
-        Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
+        let expr_loc = self.loc(expr_span);
+        self.with_values_buf(|this, offset| {
+            for &arg in args {
+                let (state, _, origin) = this.bindings[arg].poisoned()?;
+                let LocalState::Comptime(vid) = state else {
+                    this.diag_ctx.emit_runtime_ref_in_comptime(expr_loc, this.origin_loc(origin));
+                    return Err(Poisoned);
+                };
+                this.values_buf.push(vid);
+            }
+            this.diag_ctx.record_compile_log(
+                this.eval.values,
+                &this.eval.values_buf[offset..],
+                expr_loc,
+            );
+            Ok(Ok(EvalValue::Comptime(ValueId::VOID)))
+        })
     }
 
     /// Emits MIR instructions for a runtime uninit value (memptr or struct containing memptr).

--- a/plankc/frontend/hir-eval/src/builtins.rs
+++ b/plankc/frontend/hir-eval/src/builtins.rs
@@ -403,6 +403,7 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
             Builtin::SetField => self.eval_set_field(args, builtin, expr),
             Builtin::Uninit => self.eval_uninit(args, builtin, expr),
             Builtin::ConcatCBytes => self.eval_concat_cbytes(args, expr),
+            Builtin::CompileLog => self.eval_compile_log(args, expr),
             _ => unreachable!("not a comptime dynamic builtin: {builtin}"),
         }
     }
@@ -654,6 +655,23 @@ impl<'a, 'ctx> Scope<'a, 'ctx> {
         let cbytes = self.diag_ctx.session.intern_cbytes(&buf);
         let value = self.eval.values.intern_bytes(cbytes.contents, cbytes.start, cbytes.end);
         Ok(Ok(EvalValue::Comptime(value)))
+    }
+
+    fn eval_compile_log(
+        &mut self,
+        args: &[hir::LocalId],
+        expr_span: SourceSpan,
+    ) -> MaybePoisoned<Result<EvalValue, Diverge>> {
+        let &[obj] = args else { unreachable!("arg count checked") };
+        let (state, _, origin) = self.bindings[obj].poisoned()?;
+        let LocalState::Comptime(obj_vid) = state else {
+            self.diag_ctx
+                .emit_runtime_ref_in_comptime(self.loc(expr_span), self.origin_loc(origin));
+            return Err(Poisoned);
+        };
+
+        self.diag_ctx.emit_compile_log(self.eval.values, obj_vid, self.loc(expr_span));
+        return Ok(Ok(EvalValue::Comptime(ValueId::VOID)));
     }
 
     /// Emits MIR instructions for a runtime uninit value (memptr or struct containing memptr).

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -1177,17 +1177,8 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn record_compile_log(
-        &mut self,
-        values: &ValueInterner,
-        value_ids: &[ValueId],
-        loc: SrcLoc,
-    ) {
-        let msg = value_ids
-            .iter()
-            .map(|&value_id| values.format_value(self.session, self.types, value_id).to_string())
-            .collect::<Vec<_>>()
-            .join(" ");
+    pub fn record_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
+        let msg = values.format_value(self.session, self.types, value_id).to_string();
         self.session.emit_compile_log(CompileLog { loc, msg });
     }
 

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -1177,8 +1177,17 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn record_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
-        let msg = values.format_value(self.session, self.types, value_id).to_string();
+    pub fn record_compile_log(
+        &mut self,
+        values: &ValueInterner,
+        value_ids: &[ValueId],
+        loc: SrcLoc,
+    ) {
+        let msg = value_ids
+            .iter()
+            .map(|&value_id| values.format_value(self.session, self.types, value_id).to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
         self.session.emit_compile_log(CompileLog { loc, msg });
     }
 

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -3,7 +3,7 @@ use plank_core::{Span, must_use::MustUseStrict};
 use plank_hir::{self as hir, operators::BinaryOp};
 use plank_session::{Builtin, builtins::builtin_names, diagnostic::fmt_count, *};
 use plank_values::{
-    Compound, StructRef, TupleRef, Type, TypeFlags, TypeId, TypeInterner, ValueInterner,
+    Compound, StructRef, TupleRef, Type, TypeFlags, TypeId, TypeInterner, ValueInterner, ValueId,
     builtins as builtin_sigs,
 };
 
@@ -1176,4 +1176,18 @@ impl DiagCtx<'_> {
             .element(Element::Origin { path: source })
             .emit(self);
     }
+
+    pub fn emit_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
+    	if !self.session.has_compile_logs() {
+            Diagnostic::error(format!("found compile log"))
+                .element(
+                    Annotations::new(loc.source).no_label(loc.span, AnnotationKind::Primary)
+                ).emit(self);
+        }
+	    let log = CompileLog {
+	      	loc,
+       	    msg: format!("{}", values.format_value(self.session, self.types, value_id))
+	    };
+	    self.session.emit_compile_log(log);
+	}
 }

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -3,7 +3,7 @@ use plank_core::{Span, must_use::MustUseStrict};
 use plank_hir::{self as hir, operators::BinaryOp};
 use plank_session::{Builtin, builtins::builtin_names, diagnostic::fmt_count, *};
 use plank_values::{
-    Compound, StructRef, TupleRef, Type, TypeFlags, TypeId, TypeInterner, ValueInterner, ValueId,
+    Compound, StructRef, TupleRef, Type, TypeFlags, TypeId, TypeInterner, ValueId, ValueInterner,
     builtins as builtin_sigs,
 };
 
@@ -1178,16 +1178,15 @@ impl DiagCtx<'_> {
     }
 
     pub fn emit_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
-    	if !self.session.has_compile_logs() {
-            Diagnostic::error(format!("found compile log"))
-                .element(
-                    Annotations::new(loc.source).no_label(loc.span, AnnotationKind::Primary)
-                ).emit(self);
+        if !self.session.has_compile_logs() {
+            Diagnostic::error("found compile log")
+                .element(Annotations::new(loc.source).no_label(loc.span, AnnotationKind::Primary))
+                .emit(self);
         }
-	    let log = CompileLog {
-	      	loc,
-       	    msg: format!("{}", values.format_value(self.session, self.types, value_id))
-	    };
-	    self.session.emit_compile_log(log);
-	}
+        let log = CompileLog {
+            loc,
+            msg: format!("{}", values.format_value(self.session, self.types, value_id)),
+        };
+        self.session.emit_compile_log(log);
+    }
 }

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -1177,13 +1177,6 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn record_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
-        let msg = values.format_value(self.session, self.types, value_id).to_string();
-        self.session.emit_compile_log(CompileLog { loc, msg });
-    }
-
-    /// Emits the umbrella "found compile log statement" error, anchored at the first
-    /// `@compile_log` call site.
     pub fn emit_found_compile_log(&mut self, first_loc: SrcLoc) {
         Diagnostic::error("found compile log statement")
             .element(
@@ -1191,5 +1184,11 @@ impl DiagCtx<'_> {
                     .no_label(first_loc.span, AnnotationKind::Primary),
             )
             .emit(self);
+    }
+
+    // TODO: Code smell due to https://github.com/plankevm/plank-monorepo/issues/253
+    pub fn record_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
+        let msg = values.format_value(self.session, self.types, value_id).to_string();
+        self.session.emit_compile_log(CompileLog { loc, msg });
     }
 }

--- a/plankc/frontend/hir-eval/src/diagnostics.rs
+++ b/plankc/frontend/hir-eval/src/diagnostics.rs
@@ -1177,16 +1177,19 @@ impl DiagCtx<'_> {
             .emit(self);
     }
 
-    pub fn emit_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
-        if !self.session.has_compile_logs() {
-            Diagnostic::error("found compile log")
-                .element(Annotations::new(loc.source).no_label(loc.span, AnnotationKind::Primary))
-                .emit(self);
-        }
-        let log = CompileLog {
-            loc,
-            msg: format!("{}", values.format_value(self.session, self.types, value_id)),
-        };
-        self.session.emit_compile_log(log);
+    pub fn record_compile_log(&mut self, values: &ValueInterner, value_id: ValueId, loc: SrcLoc) {
+        let msg = values.format_value(self.session, self.types, value_id).to_string();
+        self.session.emit_compile_log(CompileLog { loc, msg });
+    }
+
+    /// Emits the umbrella "found compile log statement" error, anchored at the first
+    /// `@compile_log` call site.
+    pub fn emit_found_compile_log(&mut self, first_loc: SrcLoc) {
+        Diagnostic::error("found compile log statement")
+            .element(
+                Annotations::new(first_loc.source)
+                    .no_label(first_loc.span, AnnotationKind::Primary),
+            )
+            .emit(self);
     }
 }

--- a/plankc/frontend/hir-eval/src/lib.rs
+++ b/plankc/frontend/hir-eval/src/lib.rs
@@ -62,8 +62,7 @@ pub fn evaluate(
         let _ = evaluator.evaluate_const(const_id, &mut diag_ctx);
     }
 
-    // A leftover `@compile_log` fails the build, but only when nothing else already has:
-    // an otherwise-broken build keeps its real errors while the logs are still printed.
+    // A leftover `@compile_log` fails the build, but only when nothing else already has
     if let Some(first_loc) = diag_ctx.session.compile_logs().first().map(|log| log.loc)
         && !diag_ctx.session.has_errors()
     {

--- a/plankc/frontend/hir-eval/src/lib.rs
+++ b/plankc/frontend/hir-eval/src/lib.rs
@@ -62,6 +62,14 @@ pub fn evaluate(
         let _ = evaluator.evaluate_const(const_id, &mut diag_ctx);
     }
 
+    // A leftover `@compile_log` fails the build, but only when nothing else already has:
+    // an otherwise-broken build keeps its real errors while the logs are still printed.
+    if let Some(first_loc) = diag_ctx.session.compile_logs().first().map(|log| log.loc)
+        && !diag_ctx.session.has_errors()
+    {
+        diag_ctx.emit_found_compile_log(first_loc);
+    }
+
     Mir {
         blocks: evaluator.mir_blocks,
         args: evaluator.mir_args,

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -25,6 +25,39 @@ fn test_compile_log() {
     );
 }
 
+/// `@compile_log` is variadic: every argument is formatted and joined with a single space
+/// into one logged line.
+#[test]
+fn test_compile_log_multiple_values_joined_with_space() {
+    assert_compile_logs(
+        r#"
+        init {
+            comptime {
+                @compile_log(1, true, "three");
+            }
+            @evm_stop();
+        }
+        "#,
+        &[r#"1 true "three""#],
+    );
+}
+
+/// A `@compile_log` with no arguments still records an (empty) log line.
+#[test]
+fn test_compile_log_no_args() {
+    assert_compile_logs(
+        r#"
+        init {
+            comptime {
+                @compile_log();
+            }
+            @evm_stop();
+        }
+        "#,
+        &[""],
+    );
+}
+
 #[test]
 fn test_compile_log_usage_emits_error_diagnostic() {
     assert_diagnostics(

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn test_compile_log() {
+    assert_compile_logs(
+        std_project(
+            r#"
+            import std::option::Some;
+
+            init {
+                comptime {
+                    let computed = @evm_add(20, 22);
+                    @compile_log(true);
+                    @compile_log(42);
+                    @compile_log("foo");
+                    @compile_log(computed);
+                    @compile_log(u256);
+                    @compile_log(struct { id: u256 });
+                }
+                @evm_stop();
+            }
+            "#,
+        ),
+        &["true", "42", r#""foo""#, "42", "u256", "struct@main.plk:11:22"],
+    );
+}
+
+#[test]
+fn test_compile_log_usage_emits_error_diagnostic() {
+    assert_diagnostics(
+        r#"
+        init {
+            comptime {
+                @compile_log(1);
+                @compile_log(2);
+            }
+            @evm_stop();
+        }
+        "#,
+        &[r#"
+        error: found compile log
+         --> main.plk:3:9
+          |
+        3 |         @compile_log(1);
+          |         ^^^^^^^^^^^^^^^
+        "#],
+    );
+}

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -6,15 +6,13 @@ fn test_compile_log() {
         std_project(
             r#"
     import std::option::Some;
-
     init {
         comptime {
-            let computed = @evm_add(20, 22);
             @compile_log(true);
             @compile_log(42);
             @compile_log("foo");
-            @compile_log(computed);
             @compile_log(u256);
+            @compile_log(Some(42));
             @compile_log(struct { id: u256 });
         }
         @evm_stop();
@@ -23,12 +21,19 @@ fn test_compile_log() {
         ),
         &[r#"
         error: found compile log statement
-         --> main.plk:6:9
+         --> main.plk:4:9
           |
-        6 |         @compile_log(true);
+        4 |         @compile_log(true);
           |         ^^^^^^^^^^^^^^^^^^
         "#],
-        &["true", "42", r#""foo""#, "42", "u256", "struct@main.plk:11:22"],
+        &[
+            "true",
+            "42",
+            r#""foo""#,
+            "u256",
+            "Option(u256) { inner: 42, is_some: true }",
+            "struct@main.plk:9:22",
+        ],
     );
 }
 

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -25,39 +25,6 @@ fn test_compile_log() {
     );
 }
 
-/// `@compile_log` is variadic: every argument is formatted and joined with a single space
-/// into one logged line.
-#[test]
-fn test_compile_log_multiple_values_joined_with_space() {
-    assert_compile_logs(
-        r#"
-        init {
-            comptime {
-                @compile_log(1, true, "three");
-            }
-            @evm_stop();
-        }
-        "#,
-        &[r#"1 true "three""#],
-    );
-}
-
-/// A `@compile_log` with no arguments still records an (empty) log line.
-#[test]
-fn test_compile_log_no_args() {
-    assert_compile_logs(
-        r#"
-        init {
-            comptime {
-                @compile_log();
-            }
-            @evm_stop();
-        }
-        "#,
-        &[""],
-    );
-}
-
 #[test]
 fn test_compile_log_usage_emits_error_diagnostic() {
     assert_diagnostics(

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -38,11 +38,75 @@ fn test_compile_log_usage_emits_error_diagnostic() {
         }
         "#,
         &[r#"
-        error: found compile log
+        error: found compile log statement
          --> main.plk:3:9
           |
         3 |         @compile_log(1);
           |         ^^^^^^^^^^^^^^^
         "#],
+    );
+}
+
+/// All logs accumulate in order, but the umbrella error is emitted once, anchored at the
+/// first call site.
+#[test]
+fn test_compile_log_accumulates_across_sites() {
+    assert_compile_logs(
+        r#"
+        init {
+            comptime {
+                @compile_log(1);
+                @compile_log(2);
+            }
+            @evm_stop();
+        }
+        "#,
+        &["1", "2"],
+    );
+}
+
+/// When another error already exists, the logs are still recorded (and printed by the
+/// driver) but the umbrella "found compile log statement" error is suppressed.
+#[test]
+fn test_compile_log_error_suppressed_when_other_errors_exist() {
+    let (_, _, session) = try_lower(
+        r#"
+        init {
+            comptime {
+                @compile_log(1);
+            }
+            let x: bool = 5;
+            @evm_stop();
+        }
+        "#,
+    );
+    assert!(session.has_errors(), "the unrelated type error should be present");
+    let has_umbrella = session
+        .diagnostics()
+        .iter()
+        .any(|d| d.render_plain(&session).contains("found compile log statement"));
+    assert!(!has_umbrella, "umbrella error must be suppressed when other errors exist");
+    assert!(!session.compile_logs().is_empty(), "the log should still be recorded");
+}
+
+/// Logging a value that is only known at runtime is rejected: `@compile_log` requires a
+/// comptime-known operand, and nothing is recorded when the operand cannot be evaluated.
+#[test]
+fn test_compile_log_rejects_runtime_value() {
+    let (_, _, session) = try_lower(
+        r#"
+        init {
+            let x: u256 = @evm_caller();
+            comptime {
+                @compile_log(x);
+            }
+            @evm_stop();
+        }
+        "#,
+    );
+    assert!(session.has_errors(), "expected an error for runtime value in @compile_log");
+    assert!(
+        session.compile_logs().is_empty(),
+        "no compile log should be recorded for a rejected runtime value",
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/compile_log.rs
+++ b/plankc/frontend/hir-eval/src/tests/compile_log.rs
@@ -2,74 +2,39 @@ use super::*;
 
 #[test]
 fn test_compile_log() {
-    assert_compile_logs(
+    assert_diagnostics_and_compile_logs(
         std_project(
             r#"
-            import std::option::Some;
+    import std::option::Some;
 
-            init {
-                comptime {
-                    let computed = @evm_add(20, 22);
-                    @compile_log(true);
-                    @compile_log(42);
-                    @compile_log("foo");
-                    @compile_log(computed);
-                    @compile_log(u256);
-                    @compile_log(struct { id: u256 });
-                }
-                @evm_stop();
-            }
-            "#,
+    init {
+        comptime {
+            let computed = @evm_add(20, 22);
+            @compile_log(true);
+            @compile_log(42);
+            @compile_log("foo");
+            @compile_log(computed);
+            @compile_log(u256);
+            @compile_log(struct { id: u256 });
+        }
+        @evm_stop();
+    }
+    "#,
         ),
+        &[r#"
+        error: found compile log statement
+         --> main.plk:6:9
+          |
+        6 |         @compile_log(true);
+          |         ^^^^^^^^^^^^^^^^^^
+        "#],
         &["true", "42", r#""foo""#, "42", "u256", "struct@main.plk:11:22"],
     );
 }
 
 #[test]
-fn test_compile_log_usage_emits_error_diagnostic() {
-    assert_diagnostics(
-        r#"
-        init {
-            comptime {
-                @compile_log(1);
-                @compile_log(2);
-            }
-            @evm_stop();
-        }
-        "#,
-        &[r#"
-        error: found compile log statement
-         --> main.plk:3:9
-          |
-        3 |         @compile_log(1);
-          |         ^^^^^^^^^^^^^^^
-        "#],
-    );
-}
-
-/// All logs accumulate in order, but the umbrella error is emitted once, anchored at the
-/// first call site.
-#[test]
-fn test_compile_log_accumulates_across_sites() {
-    assert_compile_logs(
-        r#"
-        init {
-            comptime {
-                @compile_log(1);
-                @compile_log(2);
-            }
-            @evm_stop();
-        }
-        "#,
-        &["1", "2"],
-    );
-}
-
-/// When another error already exists, the logs are still recorded (and printed by the
-/// driver) but the umbrella "found compile log statement" error is suppressed.
-#[test]
 fn test_compile_log_error_suppressed_when_other_errors_exist() {
-    let (_, _, session) = try_lower(
+    assert_diagnostics_and_compile_logs(
         r#"
         init {
             comptime {
@@ -79,21 +44,22 @@ fn test_compile_log_error_suppressed_when_other_errors_exist() {
             @evm_stop();
         }
         "#,
+        &[r#"
+        error: mismatched types
+         --> main.plk:5:19
+          |
+        5 |     let x: bool = 5;
+          |            ----   ^ expected `bool`, got `u256`
+          |            |
+          |            `bool` expected because of this
+        "#],
+        &["1"],
     );
-    assert!(session.has_errors(), "the unrelated type error should be present");
-    let has_umbrella = session
-        .diagnostics()
-        .iter()
-        .any(|d| d.render_plain(&session).contains("found compile log statement"));
-    assert!(!has_umbrella, "umbrella error must be suppressed when other errors exist");
-    assert!(!session.compile_logs().is_empty(), "the log should still be recorded");
 }
 
-/// Logging a value that is only known at runtime is rejected: `@compile_log` requires a
-/// comptime-known operand, and nothing is recorded when the operand cannot be evaluated.
 #[test]
 fn test_compile_log_rejects_runtime_value() {
-    let (_, _, session) = try_lower(
+    assert_diagnostics_and_compile_logs(
         r#"
         init {
             let x: u256 = @evm_caller();
@@ -103,10 +69,13 @@ fn test_compile_log_rejects_runtime_value() {
             @evm_stop();
         }
         "#,
-    );
-    assert!(session.has_errors(), "expected an error for runtime value in @compile_log");
-    assert!(
-        session.compile_logs().is_empty(),
-        "no compile log should be recorded for a rejected runtime value",
+        &[r#"
+        error: attempting to evaluate runtime expression in comptime context
+         --> main.plk:4:22
+          |
+        4 |         @compile_log(x);
+          |                      ^ runtime expression
+        "#],
+        &[],
     );
 }

--- a/plankc/frontend/hir-eval/src/tests/mod.rs
+++ b/plankc/frontend/hir-eval/src/tests/mod.rs
@@ -67,7 +67,7 @@ fn assert_project_diagnostics(test_project: impl Into<TestProject>, expected: &[
 #[track_caller]
 fn assert_compile_logs(source: impl Into<TestProject>, expected: &[&str]) {
     let (_, _, session) = try_lower(source);
-    let actual: Vec<String> = session.compile_logs().iter().map(|log| log.format()).collect();
+    let actual: Vec<String> = session.compile_logs().iter().map(|log| log.to_string()).collect();
     let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
     pretty_assertions::assert_eq!(actual, expected);
 }

--- a/plankc/frontend/hir-eval/src/tests/mod.rs
+++ b/plankc/frontend/hir-eval/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod calls;
+mod compile_log;
 mod comptime;
 mod logical_ops;
 mod operators;
@@ -57,4 +58,16 @@ fn assert_diagnostics(source: impl Into<TestProject>, expected: &[&str]) {
 fn assert_project_diagnostics(test_project: impl Into<TestProject>, expected: &[&str]) {
     let (_, _, session) = try_lower(test_project);
     plank_test_utils::assert_diagnostics(session.diagnostics(), &session, expected);
+}
+
+/// Asserts that lowering `source` produces exactly the given compile logs, in order.
+///
+/// Each entry of `expected` is matched against the rendered form of one `CompileLog`
+/// recorded on the session by `@compile_log`.
+#[track_caller]
+fn assert_compile_logs(source: impl Into<TestProject>, expected: &[&str]) {
+    let (_, _, session) = try_lower(source);
+    let actual: Vec<String> = session.compile_logs().iter().map(|log| log.format()).collect();
+    let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+    pretty_assertions::assert_eq!(actual, expected);
 }

--- a/plankc/frontend/hir-eval/src/tests/mod.rs
+++ b/plankc/frontend/hir-eval/src/tests/mod.rs
@@ -60,14 +60,17 @@ fn assert_project_diagnostics(test_project: impl Into<TestProject>, expected: &[
     plank_test_utils::assert_diagnostics(session.diagnostics(), &session, expected);
 }
 
-/// Asserts that lowering `source` produces exactly the given compile logs, in order.
-///
-/// Each entry of `expected` is matched against the rendered form of one `CompileLog`
-/// recorded on the session by `@compile_log`.
 #[track_caller]
-fn assert_compile_logs(source: impl Into<TestProject>, expected: &[&str]) {
+fn assert_diagnostics_and_compile_logs(
+    source: impl Into<TestProject>,
+    expected_diagnostics: &[&str],
+    expected_logs: &[&str],
+) {
     let (_, _, session) = try_lower(source);
-    let actual: Vec<String> = session.compile_logs().iter().map(|log| log.to_string()).collect();
-    let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-    pretty_assertions::assert_eq!(actual, expected);
+    plank_test_utils::assert_diagnostics(session.diagnostics(), &session, expected_diagnostics);
+
+    let actual_logs: Vec<String> =
+        session.compile_logs().iter().map(|log| log.to_string()).collect();
+    let expected_logs: Vec<String> = expected_logs.iter().map(|s| s.to_string()).collect();
+    pretty_assertions::assert_eq!(actual_logs, expected_logs);
 }

--- a/plankc/frontend/session/src/builtins.rs
+++ b/plankc/frontend/session/src/builtins.rs
@@ -381,6 +381,7 @@ define_builtins! {
         SET_FIELD "@set_field" => SetField(3);
         UNINIT "@uninit" => Uninit(1);
         CONCAT_CBYTES "@concat_cbytes" => ConcatCBytes(1);
+        COMPILE_LOG "@compile_log" => CompileLog(1);
     }
 
     builtin_attribute {

--- a/plankc/frontend/session/src/builtins.rs
+++ b/plankc/frontend/session/src/builtins.rs
@@ -7,14 +7,7 @@ pub enum BuiltinKind {
     RuntimeFoldable,
     RuntimeOnly,
     Comptime,
-    ComptimeDynamic { arity: Arity },
-}
-
-/// How many arguments a comptime-dynamic builtin accepts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Arity {
-    Exact(usize),
-    Variadic,
+    ComptimeDynamic { arg_count: usize },
 }
 
 macro_rules! define_builtins {
@@ -32,7 +25,7 @@ macro_rules! define_builtins {
             $($ct_const:ident $ct_str:literal => $ct_variant:ident;)*
         }
         comptime_dynamic_builtins {
-            $($cd_const:ident $cd_str:literal => $cd_variant:ident($cd_arity:expr);)*
+            $($cd_const:ident $cd_str:literal => $cd_variant:ident($cd_arg_count:literal);)*
         }
         builtin_attribute {
             $($builtin_attr:ident = $builtin_attr_str:literal;)*
@@ -148,7 +141,7 @@ macro_rules! define_builtins {
                     Self::Runtime(runtime) if runtime.foldable() => BuiltinKind::RuntimeFoldable,
                     Self::Runtime(_) => BuiltinKind::RuntimeOnly,
                     $(Self::$ct_variant => BuiltinKind::Comptime,)*
-                    $(Self::$cd_variant => BuiltinKind::ComptimeDynamic { arity: $cd_arity },)*
+                    $(Self::$cd_variant => BuiltinKind::ComptimeDynamic { arg_count: $cd_arg_count },)*
                 }
             }
         }
@@ -382,13 +375,13 @@ define_builtins! {
     }
 
     comptime_dynamic_builtins {
-        FIELD_TYPE "@field_type" => FieldType(Arity::Exact(2));
-        TYPE_INDEX "@type_index" => TypeIndex(Arity::Exact(1));
-        GET_FIELD "@get_field" => GetField(Arity::Exact(2));
-        SET_FIELD "@set_field" => SetField(Arity::Exact(3));
-        UNINIT "@uninit" => Uninit(Arity::Exact(1));
-        CONCAT_CBYTES "@concat_cbytes" => ConcatCBytes(Arity::Exact(1));
-        COMPILE_LOG "@compile_log" => CompileLog(Arity::Variadic);
+        FIELD_TYPE "@field_type" => FieldType(2);
+        TYPE_INDEX "@type_index" => TypeIndex(1);
+        GET_FIELD "@get_field" => GetField(2);
+        SET_FIELD "@set_field" => SetField(3);
+        UNINIT "@uninit" => Uninit(1);
+        CONCAT_CBYTES "@concat_cbytes" => ConcatCBytes(1);
+        COMPILE_LOG "@compile_log" => CompileLog(1);
     }
 
     builtin_attribute {

--- a/plankc/frontend/session/src/builtins.rs
+++ b/plankc/frontend/session/src/builtins.rs
@@ -7,7 +7,14 @@ pub enum BuiltinKind {
     RuntimeFoldable,
     RuntimeOnly,
     Comptime,
-    ComptimeDynamic { arg_count: usize },
+    ComptimeDynamic { arity: Arity },
+}
+
+/// How many arguments a comptime-dynamic builtin accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arity {
+    Exact(usize),
+    Variadic,
 }
 
 macro_rules! define_builtins {
@@ -25,7 +32,7 @@ macro_rules! define_builtins {
             $($ct_const:ident $ct_str:literal => $ct_variant:ident;)*
         }
         comptime_dynamic_builtins {
-            $($cd_const:ident $cd_str:literal => $cd_variant:ident($cd_arg_count:literal);)*
+            $($cd_const:ident $cd_str:literal => $cd_variant:ident($cd_arity:expr);)*
         }
         builtin_attribute {
             $($builtin_attr:ident = $builtin_attr_str:literal;)*
@@ -141,7 +148,7 @@ macro_rules! define_builtins {
                     Self::Runtime(runtime) if runtime.foldable() => BuiltinKind::RuntimeFoldable,
                     Self::Runtime(_) => BuiltinKind::RuntimeOnly,
                     $(Self::$ct_variant => BuiltinKind::Comptime,)*
-                    $(Self::$cd_variant => BuiltinKind::ComptimeDynamic { arg_count: $cd_arg_count },)*
+                    $(Self::$cd_variant => BuiltinKind::ComptimeDynamic { arity: $cd_arity },)*
                 }
             }
         }
@@ -375,13 +382,13 @@ define_builtins! {
     }
 
     comptime_dynamic_builtins {
-        FIELD_TYPE "@field_type" => FieldType(2);
-        TYPE_INDEX "@type_index" => TypeIndex(1);
-        GET_FIELD "@get_field" => GetField(2);
-        SET_FIELD "@set_field" => SetField(3);
-        UNINIT "@uninit" => Uninit(1);
-        CONCAT_CBYTES "@concat_cbytes" => ConcatCBytes(1);
-        COMPILE_LOG "@compile_log" => CompileLog(1);
+        FIELD_TYPE "@field_type" => FieldType(Arity::Exact(2));
+        TYPE_INDEX "@type_index" => TypeIndex(Arity::Exact(1));
+        GET_FIELD "@get_field" => GetField(Arity::Exact(2));
+        SET_FIELD "@set_field" => SetField(Arity::Exact(3));
+        UNINIT "@uninit" => Uninit(Arity::Exact(1));
+        CONCAT_CBYTES "@concat_cbytes" => ConcatCBytes(Arity::Exact(1));
+        COMPILE_LOG "@compile_log" => CompileLog(Arity::Variadic);
     }
 
     builtin_attribute {

--- a/plankc/frontend/session/src/compile_log.rs
+++ b/plankc/frontend/session/src/compile_log.rs
@@ -1,0 +1,20 @@
+use crate::SrcLoc;
+use std::path::PathBuf;
+
+use super::Session;
+
+#[derive(Debug, Clone)]
+pub struct CompileLog {
+	pub loc: SrcLoc,
+	pub msg: String,
+}
+
+impl CompileLog {
+    pub fn format(&self, session: &Session) -> String {
+        let source = session.get_source(self.loc.source);
+        let last_two: PathBuf = source.path.components().rev().take(2).collect::<Vec<_>>()
+            .into_iter().rev().collect();
+        let (line, col) = session.offset_to_line_col(self.loc.source, self.loc.span.start);
+        format!("[{}:{}:{}] {}", last_two.display(), line, col, self.msg)
+    }
+}

--- a/plankc/frontend/session/src/compile_log.rs
+++ b/plankc/frontend/session/src/compile_log.rs
@@ -1,20 +1,13 @@
 use crate::SrcLoc;
-use std::path::PathBuf;
-
-use super::Session;
 
 #[derive(Debug, Clone)]
 pub struct CompileLog {
-	pub loc: SrcLoc,
-	pub msg: String,
+    pub loc: SrcLoc,
+    pub msg: String,
 }
 
 impl CompileLog {
-    pub fn format(&self, session: &Session) -> String {
-        let source = session.get_source(self.loc.source);
-        let last_two: PathBuf = source.path.components().rev().take(2).collect::<Vec<_>>()
-            .into_iter().rev().collect();
-        let (line, col) = session.offset_to_line_col(self.loc.source, self.loc.span.start);
-        format!("[{}:{}:{}] {}", last_two.display(), line, col, self.msg)
+    pub fn format(&self) -> String {
+        self.msg.clone()
     }
 }

--- a/plankc/frontend/session/src/compile_log.rs
+++ b/plankc/frontend/session/src/compile_log.rs
@@ -1,4 +1,5 @@
 use crate::SrcLoc;
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct CompileLog {
@@ -6,8 +7,8 @@ pub struct CompileLog {
     pub msg: String,
 }
 
-impl CompileLog {
-    pub fn format(&self) -> String {
-        self.msg.clone()
+impl fmt::Display for CompileLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.msg)
     }
 }

--- a/plankc/frontend/session/src/lib.rs
+++ b/plankc/frontend/session/src/lib.rs
@@ -6,11 +6,11 @@ mod interner;
 pub mod poison;
 
 pub use builtins::{Builtin, RuntimeBuiltin};
+pub use compile_log::CompileLog;
 pub use diagnostic::*;
 pub use display::write_bytes_literal;
 pub use interner::{BytesId, EMPTY_BYTES, StrId};
 pub use poison::{MaybePoisoned, Poisoned};
-pub use compile_log::CompileLog;
 
 use interner::Interner;
 use plank_core::{Idx, IndexVec, Span, newtype_index};
@@ -138,7 +138,7 @@ impl Session {
     }
 
     pub fn has_compile_logs(&self) -> bool {
-        self.compile_logs.len() > 0
+        !self.compile_logs.is_empty()
     }
 
     /// Both line and col are 1-indexed. O(n) linear scan.
@@ -162,8 +162,8 @@ impl Session {
     }
 
     pub fn emit_compile_log(&mut self, log: CompileLog) {
-    	self.compile_logs.push(log);
-	}
+        self.compile_logs.push(log);
+    }
 }
 
 impl DiagEmitter for Session {

--- a/plankc/frontend/session/src/lib.rs
+++ b/plankc/frontend/session/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod builtins;
+pub mod compile_log;
 pub mod diagnostic;
 pub mod display;
 mod interner;
@@ -9,6 +10,7 @@ pub use diagnostic::*;
 pub use display::write_bytes_literal;
 pub use interner::{BytesId, EMPTY_BYTES, StrId};
 pub use poison::{MaybePoisoned, Poisoned};
+pub use compile_log::CompileLog;
 
 use interner::Interner;
 use plank_core::{Idx, IndexVec, Span, newtype_index};
@@ -37,6 +39,7 @@ pub struct Session {
     source_map: IndexVec<SourceId, Source>,
     total_errors: u32,
     diagnostics: Vec<Diagnostic>,
+    compile_logs: Vec<CompileLog>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -63,6 +66,7 @@ impl Session {
             source_map: IndexVec::new(),
             total_errors: 0,
             diagnostics: Vec::new(),
+            compile_logs: Vec::new(),
         };
         builtins::inject_builtins(&mut this);
         this
@@ -125,8 +129,16 @@ impl Session {
         &self.diagnostics
     }
 
+    pub fn compile_logs(&self) -> &[CompileLog] {
+        &self.compile_logs
+    }
+
     pub fn has_errors(&self) -> bool {
         self.total_errors() > 0
+    }
+
+    pub fn has_compile_logs(&self) -> bool {
+        self.compile_logs.len() > 0
     }
 
     /// Both line and col are 1-indexed. O(n) linear scan.
@@ -148,6 +160,10 @@ impl Session {
         }
         (line, col)
     }
+
+    pub fn emit_compile_log(&mut self, log: CompileLog) {
+    	self.compile_logs.push(log);
+	}
 }
 
 impl DiagEmitter for Session {

--- a/plankc/frontend/values/src/builtins.rs
+++ b/plankc/frontend/values/src/builtins.rs
@@ -1,7 +1,4 @@
-use plank_session::{
-    Builtin, RuntimeBuiltin, StrId,
-    builtins::{Arity, BuiltinKind},
-};
+use plank_session::{Builtin, RuntimeBuiltin, StrId, builtins::BuiltinKind};
 
 use crate::TypeId;
 
@@ -11,16 +8,9 @@ pub struct BuiltinSignature {
     pub result: TypeId,
 }
 
-/// The fixed argument count of `builtin`.
-///
-/// Only valid for builtins with a fixed arity; querying a variadic builtin is a bug, since
-/// there is no single count to report.
 pub fn arg_count(builtin: Builtin) -> usize {
     match builtin.kind() {
-        BuiltinKind::ComptimeDynamic { arity: Arity::Exact(n) } => n,
-        BuiltinKind::ComptimeDynamic { arity: Arity::Variadic } => {
-            unreachable!("arg_count queried for variadic builtin {builtin:?}")
-        }
+        BuiltinKind::ComptimeDynamic { arg_count } => arg_count,
         _ => builtin_signatures(builtin)[0].inputs.len(),
     }
 }

--- a/plankc/frontend/values/src/builtins.rs
+++ b/plankc/frontend/values/src/builtins.rs
@@ -236,7 +236,7 @@ pub fn builtin_signatures(builtin: Builtin) -> &'static [BuiltinSignature] {
         B::ActiveEvmVersion => &[sig!([=> U256])],
 
         // Comptime dynamic — no fixed signatures
-        B::FieldType | B::TypeIndex | B::GetField | B::SetField | B::Uninit | B::ConcatCBytes => {
+        B::FieldType | B::TypeIndex | B::GetField | B::SetField | B::Uninit | B::ConcatCBytes | B::CompileLog => {
             &[]
         }
     }

--- a/plankc/frontend/values/src/builtins.rs
+++ b/plankc/frontend/values/src/builtins.rs
@@ -236,9 +236,13 @@ pub fn builtin_signatures(builtin: Builtin) -> &'static [BuiltinSignature] {
         B::ActiveEvmVersion => &[sig!([=> U256])],
 
         // Comptime dynamic — no fixed signatures
-        B::FieldType | B::TypeIndex | B::GetField | B::SetField | B::Uninit | B::ConcatCBytes | B::CompileLog => {
-            &[]
-        }
+        B::FieldType
+        | B::TypeIndex
+        | B::GetField
+        | B::SetField
+        | B::Uninit
+        | B::ConcatCBytes
+        | B::CompileLog => &[],
     }
 }
 

--- a/plankc/frontend/values/src/builtins.rs
+++ b/plankc/frontend/values/src/builtins.rs
@@ -1,4 +1,7 @@
-use plank_session::{Builtin, RuntimeBuiltin, StrId, builtins::BuiltinKind};
+use plank_session::{
+    Builtin, RuntimeBuiltin, StrId,
+    builtins::{Arity, BuiltinKind},
+};
 
 use crate::TypeId;
 
@@ -8,9 +11,16 @@ pub struct BuiltinSignature {
     pub result: TypeId,
 }
 
+/// The fixed argument count of `builtin`.
+///
+/// Only valid for builtins with a fixed arity; querying a variadic builtin is a bug, since
+/// there is no single count to report.
 pub fn arg_count(builtin: Builtin) -> usize {
     match builtin.kind() {
-        BuiltinKind::ComptimeDynamic { arg_count } => arg_count,
+        BuiltinKind::ComptimeDynamic { arity: Arity::Exact(n) } => n,
+        BuiltinKind::ComptimeDynamic { arity: Arity::Variadic } => {
+            unreachable!("arg_count queried for variadic builtin {builtin:?}")
+        }
         _ => builtin_signatures(builtin)[0].inputs.len(),
     }
 }


### PR DESCRIPTION
# Design

## Interface
The `@compile_log` builtin takes a single parameter of any type, which is pretty-printed. This allows users to flexibly print messages or inspect values.

## Diagnostics
An error diagnostic will be emitted if any `@compile_log` statement is found and no other errors were found. This signals to users that `@compile_log` is only for temporary debugging and should not exist in production code.

Zig has the same behaviour for its [@compileLog](https://ziglang.org/documentation/master/#compileLog) builtin.

## Logging format

Example Output for various input parameters:

```
Compile Log Output:
true
4
"foo"
tuple {cbytes, Option(u256)} ("inspecting this variable", Option(u256) { inner: 2, is_some: true })
struct@/Users/vincent/code/plank-monorepo/plankc/scratch.plk:10:22
```

Printed log lines do not contain any location metadata. This may seem shortsighted, but I'd argue such info mostly gets in the way:  

1. Printing location metadata leads to overly long lines of arbitrary lengths, potentially wrapping in the terminal and generally making it harder for the user to read the actual log message.

2. Intelligently shortening the path doesn't fully mitigate the readability problem, as you'll still end up with paths of different lengths depending on the location of the sources. In any case, intelligent shortening is a separate task in https://github.com/plankevm/plank-monorepo/issues/100.

3. Zig  [@compileLog](https://ziglang.org/documentation/master/#compileLog) doesn't print location metadata either, I'd wager for the same reasons as above.

## Open Questions

In Zig, the builtin prints both the type and value.

Code: `@compileLog(4)`

```
Compile Log Output:
@as(comptime_int, 4)
```