### PR TITLE
🐛 fix syntax-highlight grammar drift

### DIFF
--- a/plank-tree-sitter/queries/highlights.scm
+++ b/plank-tree-sitter/queries/highlights.scm
@@ -24,7 +24,7 @@
   ; EVM Comparison & Bitwise Logic
   "@evm_lt" "@evm_gt" "@evm_slt" "@evm_sgt" "@evm_eq" "@evm_iszero"
   "@evm_and" "@evm_or" "@evm_xor" "@evm_not"
-  "@evm_byte" "@evm_shl" "@evm_shr" "@evm_sar"
+  "@evm_byte" "@evm_shl" "@evm_shr" "@evm_sar" "@evm_clz"
   ; EVM Keccak-256
   "@evm_keccak256"
   ; EVM Environment Information
@@ -59,13 +59,13 @@
   ; Bytecode Introspection
   "@runtime_start_offset" "@init_end_offset" "@runtime_length"
   ; Comptime Type Reflection
-  "@is_struct" "@has_plain_name" "@has_parameterized_name" "@type_name"
+  "@is_struct" "@is_tuple" "@has_plain_name" "@has_parameterized_name" "@type_name" "@type_index"
   "@field_count" "@field_type" "@field_name" "@field_index" "@get_field" "@set_field" "@uninit"
   ; Comptime Diagnostics
-  "@compile_error" "@in_comptime" "@set_eval_branch_quota"
+  "@compile_error" "@compile_log" "@in_comptime" "@set_eval_branch_quota" "@active_evm_version"
   ; Bytes
-  "@cbytes_concat" "@cbytes_padded_read_u256" "@keccak256_cbytes" "@sha256_cbytes"
-  "@slice_cbytes" "@data_offset"
+  "@cbytes_concat" "@concat_cbytes" "@cbytes_padded_read_u256" "@padded_read_cbytes"
+  "@keccak256_cbytes" "@sha256_cbytes" "@slice_cbytes" "@data_offset"
   ))
 
 ; Function calls

--- a/plank-tree-sitter/tree-sitter.json
+++ b/plank-tree-sitter/tree-sitter.json
@@ -7,7 +7,7 @@
       "title": "Plank",
       "scope": "source.plank",
       "file-types": [
-        "plank"
+        "plk"
       ],
       "injection-regex": "^plank$",
       "class-name": "TreeSitterPlank"

--- a/plank-vscode/syntaxes/plank.tmLanguage.json
+++ b/plank-vscode/syntaxes/plank.tmLanguage.json
@@ -138,7 +138,7 @@
         {
           "comment": "EVM Comparison & Bitwise Logic",
           "name": "support.function.builtin.plank",
-          "match": "@(?:evm_lt|evm_gt|evm_slt|evm_sgt|evm_eq|evm_iszero|evm_and|evm_or|evm_xor|evm_not|evm_byte|evm_shl|evm_shr|evm_sar)\\b"
+          "match": "@(?:evm_lt|evm_gt|evm_slt|evm_sgt|evm_eq|evm_iszero|evm_and|evm_or|evm_xor|evm_not|evm_byte|evm_shl|evm_shr|evm_sar|evm_clz)\\b"
         },
         {
           "comment": "EVM Keccak-256",
@@ -188,17 +188,17 @@
         {
           "comment": "Comptime Type Reflection",
           "name": "support.function.builtin.plank",
-          "match": "@(?:is_struct|has_plain_name|has_parameterized_name|type_name|field_count|field_type|field_name|field_index|get_field|set_field)\\b"
+          "match": "@(?:is_struct|is_tuple|has_plain_name|has_parameterized_name|type_name|type_index|field_count|field_type|field_name|field_index|get_field|set_field|uninit)\\b"
         },
         {
           "comment": "Comptime Diagnostics",
           "name": "support.function.builtin.plank",
-          "match": "@compile_error\\b"
+          "match": "@(?:compile_error|compile_log|in_comptime|set_eval_branch_quota|active_evm_version)\\b"
         },
         {
           "comment": "Comptime Bytes",
           "name": "support.function.builtin.plank",
-          "match": "@(?:cbytes_concat|cbytes_padded_read_u256|keccak256_cbytes|sha256_cbytes|slice_cbytes|data_offset)\\b"
+          "match": "@(?:cbytes_concat|concat_cbytes|cbytes_padded_read_u256|padded_read_cbytes|keccak256_cbytes|sha256_cbytes|slice_cbytes|data_offset)\\b"
         }
       ]
     },


### PR DESCRIPTION
## Problem
Plank syntax highlighting was broken / incomplete in editors.

## Root causes (all grammar↔compiler drift)
1. **`plank-tree-sitter/tree-sitter.json`** declared `file-types: ["plank"]` but Plank sources use **`.plk`** → editors never associated `.plk` buffers with the grammar. Fixed to `["plk"]`.
2. **`highlights.scm`** (tree-sitter) was missing 7 real builtins.
3. **`plank.tmLanguage.json`** (VSCode) was missing those 7 + 3 more.

Recently added builtins (`clz` #254, `@compile_log` #255, EVM-version #241) landed only in the compiler, never in the grammars.

## Fix
Synced both grammars to **100% coverage** of the 169 canonical builtins in `plankc/frontend/session/src/builtins.rs`.

- `highlights.scm`: `+@evm_clz @compile_log @active_evm_version @is_tuple @type_index @concat_cbytes @padded_read_cbytes`
- `tmLanguage.json`: the above + `@in_comptime @set_eval_branch_quota @uninit`

## Verification
- Diffed both grammars against `builtins.rs`: **0 missing, 0 stale** in each.
- `tmLanguage.json` valid JSON; `highlights.scm` loads cleanly via `tree-sitter query` against real `.plk` examples.

## Follow-up (not in this PR)
Builtins live in 3 hand-maintained places with nothing keeping them in sync. A CI check that extracts `"@..."` from `builtins.rs` and diffs against both grammars would prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)