### PR TITLE
gas-optimized minimal proxy bytecode

### DIFF
--- a/plankc/plank-diff-tests/src/examples/MinimalProxy.sol
+++ b/plankc/plank-diff-tests/src/examples/MinimalProxy.sol
@@ -7,10 +7,10 @@ contract MinimalProxyFactory {
     function clone(address implementation) external returns (address result) {
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(96, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-            result := create(0, ptr, 0x37)
+            mstore(ptr, 0x602c8060095f395ff3365f5f37602a5f5f5f365f730000000000000000000000)
+            mstore(add(ptr, 0x15), shl(96, implementation))
+            mstore(add(ptr, 0x29), 0x5af43d3d5f5f3e9257fd5bf30000000000000000000000000000000000000000)
+            result := create(0, ptr, 0x35)
         }
         require(result != address(0));
         emit CloneCreated(result);
@@ -19,10 +19,10 @@ contract MinimalProxyFactory {
     function cloneDeterministic(address implementation, bytes32 salt) external returns (address result) {
         assembly {
             let ptr := mload(0x40)
-            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(ptr, 0x14), shl(96, implementation))
-            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-            result := create2(0, ptr, 0x37, salt)
+            mstore(ptr, 0x602c8060095f395ff3365f5f37602a5f5f5f365f730000000000000000000000)
+            mstore(add(ptr, 0x15), shl(96, implementation))
+            mstore(add(ptr, 0x29), 0x5af43d3d5f5f3e9257fd5bf30000000000000000000000000000000000000000)
+            result := create2(0, ptr, 0x35, salt)
         }
         require(result != address(0));
         emit CloneCreated(result);

--- a/plankc/plank-diff-tests/src/examples/minimal_proxy.plk
+++ b/plankc/plank-diff-tests/src/examples/minimal_proxy.plk
@@ -31,15 +31,15 @@ const clone_deterministic = fn () never {
 
 const deploy_clone = fn (salt: $SaltT) never {
     let address = @evm_calldataload(4);
-    let len = 32 + 20 + 15;
+    let len = 32 + 20 + 12;
     let buf = @malloc_uninit(len);
-    @mstore32(buf +% (len - 32), 0x5af43d82803e903d91602b57fd5bf3);
-    @mstore32(buf +% (len - 32 - 15), address);
-    @mstore32(buf +% (len - 32 - 15 - 20), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73);
+    @mstore32(buf +% (len - 32), 0x5af43d3d5f5f3e9257fd5bf3);
+    @mstore32(buf +% (len - 32 - 12), address);
+    @mstore32(buf +% (len - 32 - 12 - 20), 0x602c8060095f395ff3365f5f37602a5f5f5f365f73);
     let address = if SaltT == void {
-        @evm_create(0, buf +% (32 - 20), 55)
+        @evm_create(0, buf +% (32 - 21), 53)
     } else if SaltT == u256 {
-        @evm_create2(0, buf +% (32 - 20), 55, salt)
+        @evm_create2(0, buf +% (32 - 21), 53, salt)
     } else {
         @compile_error("unsupported clone salt type")
     };


### PR DESCRIPTION
# Optimized EIP-1167 Minimal Proxy — Byte & Gas Layout
 
## Bytecode
 
```
602c8060095f395ff3365f5f37602a5f5f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d3d5f5f3e9257fd5bf3
```
 
53 bytes total: **9-byte init code** + **44-byte runtime code**.
 
## Byte Layout
 
```
|--init code 9B--|---------------------run time code 44B(12+20+12)---------------------------------------|
|----------------|---copy calldata ------|----implementation contract address----|DelegateCall + Return/Revert
602c8060095f395ff3 365f5f37602a5f5f5f365f73 bebebebebebebebebebebebebebebebebebebebe 5af43d3d5f5f3e9257fd5bf3
```
| Offset | Opcode | Mnemonic | Notes | Stack after (top  → bottom) |
|---|---|---|---|---|
| `[00]` | `60 2c` | `PUSH1 0x2c` | runtime size (44) | `0x2c` |
| `[02]` | `80` | `DUP1` | | `0x2c, 0x2c` |
| `[03]` | `60 09` | `PUSH1 0x09` | offset of runtime in creation code | `0x09, 0x2c, 0x2c` |
| `[05]` | `5f` | `PUSH0` | destOffset for CODECOPY | `0, 0x09, 0x2c, 0x2c` |
| `[06]` | `39` | `CODECOPY` | copy runtime into memory | `0x2c` |
| `[07]` | `5f` | `PUSH0` | return offset | `0, 0x2c` |
| `[08]` | `f3` | `RETURN` | return runtime code — **end of init code** | *(empty)* |
| `[09]` | `36` | `CALLDATASIZE` | — **start of runtime code** | `cds` |
| `[0a]` | `5f` | `PUSH0` | | `0, cds` |
| `[0b]` | `5f` | `PUSH0` | | `0, 0, cds` |
| `[0c]` | `37` | `CALLDATACOPY` | copy calldata to memory[0:cds] | *(empty)* |
| `[0d]` | `60 2a` | `PUSH1 0x2a` | pre-stage JUMPDEST target | `0x2a` |
| `[0f]` | `5f` | `PUSH0` | | `0, 0x2a` |
| `[10]` | `5f` | `PUSH0` | | `0, 0, 0x2a` |
| `[11]` | `5f` | `PUSH0` | | `0, 0, 0, 0x2a` |
| `[12]` | `36` | `CALLDATASIZE` | | `cds, 0, 0, 0, 0x2a` |
| `[13]` | `5f` | `PUSH0` | | `0, cds, 0, 0, 0, 0x2a` |
| `[14]` | `73 <addr>` | `PUSH20 <impl>` | implementation contract address (20B) | `addr, 0, cds, 0, 0, 0, 0x2a` |
| `[29]` | `5a` | `GAS` | | `gas, addr, 0, cds, 0, 0, 0, 0x2a` |
| `[2a]` | `f4` | `DELEGATECALL` | pops gas,addr,argsOff=0,argsSize=cds,retOff=0,retSize=0 | `success, 0, 0x2a` |
| `[2b]` | `3d` | `RETURNDATASIZE` | real return-data size | `rds, success, 0, 0x2a` |
| `[2c]` | `3d` | `RETURNDATASIZE` | | `rds, rds, success, 0, 0x2a` |
| `[2d]` | `5f` | `PUSH0` | | `0, rds, rds, success, 0, 0x2a` |
| `[2e]` | `5f` | `PUSH0` | | `0, 0, rds, rds, success, 0, 0x2a` |
| `[2f]` | `3e` | `RETURNDATACOPY` | copy return data to memory[0:rds] | `rds, success, 0, 0x2a` |
| `[30]` | `92` | `SWAP3` | swap top ↔ 4th item (bring `0x2a` to top) | `0x2a, success, 0, rds` |
| `[31]` | `57` | `JUMPI` | jump to `0x2a` if `success` | `0, rds` |
| `[32]` | `fd` | `REVERT` | fallthrough on failure — reverts with memory[0:rds] | *(not reached on success)* |
| `[33]` | `5b` | `JUMPDEST` | | `0, rds` |
| `[34]` | `f3` | `RETURN` | returns memory[0:rds] — **end of runtime code** | *(empty)* |
 
**Note:** every `RETURNDATASIZE` before `DELEGATECALL` was a "free zero" (returndatasize is guaranteed 0 pre-call) and has been replaced with `PUSH0` throughout. This substitution is gas- and size-neutral (`RETURNDATASIZE` and `PUSH0` are both 1 byte / 2 gas).
 
## Gas Layout
 
### Deployment (per `deploy_clone()` call)
 
| Component | Standard (55B) | Optimized (53B) | Diff |
|---|---:|---:|---:|
| Init code execution | 31 | 28 | **-3** |
| Packing-buffer memory expansion | 9 (3 words / 67B) | 6 (2 words / 64B) | **-3** |
| [Code-deposit (`Gcodedeposit` = 200/byte)](https://eip.tools/eip/8037#motivation) | 9,000 (45B) | 8,800 (44B) | **-200** |
| `CREATE` base cost | 32,000 | 32,000 | 0 |
| EIP-3860 initcode word check | 4 (2 words) | 4 (2 words) | 0 |
| `LOG1` (`CloneCreated` event) | ~1,006 | ~1,006 | 0 |
| **Total deployment saving** | | | **-206 gas** |
 
### Runtime (per `DELEGATECALL` forwarded by any deployed clone)
 
| Component | Standard | Optimized | Diff |
|---|---:|---:|---:|
| Fixed/static opcode overhead | 51 gas | 46 gas | **-5 gas** |
| `CALLDATACOPY` / `DELEGATECALL` / `RETURNDATACOPY` dynamic cost | identical | identical | 0 |
| **Total per-call saving (forever, every call)** | | | **-5 gas** |
 
### Compatibility
 
Requires **Shanghai+** EVM (`PUSH0`, EIP-3855). Not deployable on pre-Shanghai chains.

### Next Steps:
 - [x] Add/update [MinimalProxy.sol](https://github.com/plankevm/plank-monorepo/blob/main/plankc/plank-diff-tests/src/examples/MinimalProxy.sol)
 - [ ] Update [minimal-proxy.md](https://github.com/plankevm/plank-monorepo/blob/main/plank-doc/src/examples/minimal-proxy.md)